### PR TITLE
Made MongoDB bootstrapper context thread safe.

### DIFF
--- a/src/Context.Tests/MongoCollectionBuilderTests.cs
+++ b/src/Context.Tests/MongoCollectionBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
@@ -187,6 +188,54 @@ namespace MongoDB.Extensions.Context.Tests
             Assert.Equal(ReadConcern.Majority, result.Settings.ReadConcern);
             Assert.Equal(ReadPreference.Primary, result.Settings.ReadPreference);
             Assert.True(result.Settings.AssignIdOnInsert);
+        }
+
+        #endregion
+        
+        #region WithMongoCollectionSettings Tests
+
+        [Fact]
+        public async Task WithCreateCollectionOptions_SetCappedCollectionOptions_MongoCollectionOptionsChangedToCappedSuccessfully()
+        {
+            // Arrange
+            var mongoCollectionBuilder = new MongoCollectionBuilder<Order>(_mongoDatabase);
+
+            // Act
+            mongoCollectionBuilder.WithCreateCollectionOptions(createCollectionOptions =>
+            {
+                createCollectionOptions.Capped = true;
+                createCollectionOptions.MaxSize = 1;
+                createCollectionOptions.MaxDocuments = 1;
+            });
+            IMongoCollection<Order> result = mongoCollectionBuilder.Build();
+
+            // Assert
+            var command = new BsonDocumentCommand<BsonDocument>(new BsonDocument
+            {
+                {"collstats", nameof(Order)}
+            });
+
+            BsonDocument stats = await _mongoDatabase.RunCommandAsync(command);
+            Assert.True(stats["capped"].AsBoolean);
+        }
+
+        [Fact]
+        public async Task WithCreateCollectionOptions_NoCappedCollectionOptions_DefaultMongoCollectionSettingsSet()
+        {
+            // Arrange
+            var mongoCollectionBuilder = new MongoCollectionBuilder<Order>(_mongoDatabase);
+
+            // Act
+            IMongoCollection<Order> result = mongoCollectionBuilder.Build();
+
+            // Assert
+            var command = new BsonDocumentCommand<BsonDocument>(new BsonDocument
+            {
+                {"collstats", nameof(Order)}
+            });
+
+            BsonDocument stats = await _mongoDatabase.RunCommandAsync(command);
+            Assert.False(stats["capped"].AsBoolean);
         }
 
         #endregion

--- a/src/Context/IMongoCollectionBuilder.cs
+++ b/src/Context/IMongoCollectionBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
@@ -12,10 +11,13 @@ namespace MongoDB.Extensions.Context
         IMongoCollectionBuilder<TDocument> AddBsonClassMap<TMapDocument>(
             Action<BsonClassMap<TMapDocument>> bsonClassMapAction) where TMapDocument : class;
 
+        IMongoCollectionBuilder<TDocument> WithCreateCollectionOptions(
+            Action<CreateCollectionOptions> createCollectionOptions);
+
         IMongoCollectionBuilder<TDocument> WithCollectionSettings(
             Action<MongoCollectionSettings> collectionSettings);
 
         IMongoCollectionBuilder<TDocument> WithCollectionConfiguration(
-            Action<IMongoCollection<TDocument>> collectionConfiguration);        
+            Action<IMongoCollection<TDocument>> collectionConfiguration);
     }
 }

--- a/src/Context/Internal/MongoCollectionBuilder.cs
+++ b/src/Context/Internal/MongoCollectionBuilder.cs
@@ -10,18 +10,23 @@ namespace MongoDB.Extensions.Context
         private string _collectionName;
         private readonly IMongoDatabase _mongoDatabase;
         private readonly List<Action> _classMapActions;
+        private readonly List<Action<CreateCollectionOptions>> _createCollectionOptionsActions;
         private readonly List<Action<MongoCollectionSettings>> _collectionSettingsActions;
         private readonly List<Action<IMongoCollection<TDocument>>> _collectionConfigurations;
 
+        // static lock for static BsonClassMap
+        private static readonly object _lockObject = new object();
+
         public MongoCollectionBuilder(IMongoDatabase mongoDatabase)
         {
-            _mongoDatabase = mongoDatabase ??
-                throw new ArgumentNullException(nameof(mongoDatabase));
+            _mongoDatabase = mongoDatabase 
+                ?? throw new ArgumentNullException(nameof(mongoDatabase));
 
             _collectionName = typeof(TDocument).Name;
             _classMapActions = new List<Action>();
             _collectionConfigurations = new List<Action<IMongoCollection<TDocument>>>();
             _collectionSettingsActions = new List<Action<MongoCollectionSettings>>();
+            _createCollectionOptionsActions = new List<Action<CreateCollectionOptions>>();
         }
 
         public IMongoCollectionBuilder<TDocument> WithCollectionName(string collectionName)
@@ -37,15 +42,15 @@ namespace MongoDB.Extensions.Context
         public IMongoCollectionBuilder<TDocument> AddBsonClassMap<TMapDocument>(
             Action<BsonClassMap<TMapDocument>> bsonClassMapAction) where TMapDocument : class
         {
-            Action classMapAction = () =>
-            {
-                if (!BsonClassMap.IsClassMapRegistered(typeof(TMapDocument)))
-                {
-                    BsonClassMap.RegisterClassMap(bsonClassMapAction);
-                }
-            };
+            _classMapActions.Add(() => RegisterClassMapSync(bsonClassMapAction));
 
-            _classMapActions.Add(classMapAction);
+            return this;
+        }
+        
+        public IMongoCollectionBuilder<TDocument> WithCreateCollectionOptions(
+            Action<CreateCollectionOptions> createCollectionOptions)
+        {
+            _createCollectionOptionsActions.Add(createCollectionOptions);
 
             return this;
         }
@@ -70,21 +75,46 @@ namespace MongoDB.Extensions.Context
         {
             _classMapActions.ForEach(action => action());
 
-            MongoCollectionSettings mongoCollectionSettings = null;
-            if (_collectionSettingsActions.Count != 0)
-            {
-                mongoCollectionSettings = new MongoCollectionSettings();
-                _collectionSettingsActions
-                    .ForEach(configure => configure(mongoCollectionSettings));
-            }
+            CreateMongoCollection();
 
-            IMongoCollection<TDocument> mongoCollection = _mongoDatabase
-                .GetCollection<TDocument>(_collectionName, mongoCollectionSettings);
+            IMongoCollection<TDocument> mongoCollection = GetMongoCollection();
 
-            _collectionConfigurations
-                .ForEach(configuration => configuration(mongoCollection));
+            _collectionConfigurations.ForEach(configuration => configuration(mongoCollection));
 
             return mongoCollection;
+        }
+
+        private IMongoCollection<TDocument> GetMongoCollection()
+        {
+            var mongoCollectionSettings = new MongoCollectionSettings();
+
+            _collectionSettingsActions
+                .ForEach(configure => configure(mongoCollectionSettings));
+
+            return _mongoDatabase
+                .GetCollection<TDocument>(_collectionName, mongoCollectionSettings);
+        }
+
+        private void CreateMongoCollection()
+        {
+            var createCollectionOptions = new CreateCollectionOptions();
+
+            _createCollectionOptionsActions
+                    .ForEach(configure => configure(createCollectionOptions));
+
+            _mongoDatabase.CreateCollection(_collectionName, createCollectionOptions);
+        }
+
+        private void RegisterClassMapSync<TMapDocument>(
+            Action<BsonClassMap<TMapDocument>> bsonClassMapAction) where TMapDocument : class
+        {
+            lock (_lockObject)
+            {
+                if (!BsonClassMap.IsClassMapRegistered(typeof(TMapDocument)))
+                {
+                    BsonClassMap.RegisterClassMap(bsonClassMapAction);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The MongoDB bootstrapper context was not thread safe. If several threads tried to instantiate a MongoDbContext, then errors could occur. This is fixed with this version.
