### PR TITLE
Implemented MongoDb server disable table scan option.

### DIFF
--- a/src/Context.Tests/MongoDatabaseBuilderTests.cs
+++ b/src/Context.Tests/MongoDatabaseBuilderTests.cs
@@ -358,6 +358,24 @@ namespace MongoDB.Extensions.Context.Tests
             // Assert
             Assert.Throws<ArgumentNullException>(registerSerializers);
         }
+
+        #endregion
+
+        #region DisableTableScan Tests
+
+        [Fact]
+        public void DisableTableScan_SetMongoServerTableScanToDisabled_MongoServerTableScanIsDisabled()
+        {
+            // Arrange
+            var mongoDatabaseBuilder = new MongoDatabaseBuilder(_mongoOptions);
+
+            // Act
+            mongoDatabaseBuilder.ConfigureDatabase(db => db.Client.DisableTableScan());
+            MongoDbContextData result = mongoDatabaseBuilder.Build();
+
+            // Assert
+            Assert.True(result.Client.IsTableScanDisabled());
+        }
         
         #endregion
 

--- a/src/Context/IMongoDatabaseBuilder.cs
+++ b/src/Context/IMongoDatabaseBuilder.cs
@@ -13,11 +13,13 @@ namespace MongoDB.Extensions.Context
             string name, IConventionPack conventions, Func<Type, bool> filter);
 
         IMongoDatabaseBuilder RegisterCamelCaseConventionPack();
-
+        
         IMongoDatabaseBuilder ConfigureCollection<TDocument>(
             IMongoCollectionConfiguration<TDocument> configuration) where TDocument : class;
 
         IMongoDatabaseBuilder ConfigureConnection(
             Action<MongoClientSettings> mongoClientSettingsAction);
+
+        IMongoDatabaseBuilder ConfigureDatabase(Action<IMongoDatabase> configureDatabase);
     }
 }

--- a/src/Context/Internal/MongoDatabaseBuilder.cs
+++ b/src/Context/Internal/MongoDatabaseBuilder.cs
@@ -14,6 +14,7 @@ namespace MongoDB.Extensions.Context
         private readonly List<Action> _registrationConventionActions;
         private readonly List<Action> _registrationSerializerActions;
         private readonly List<Action<MongoClientSettings>> _mongoClientSettingsActions;
+        private readonly List<Action<IMongoDatabase>> _databaseConfigurationActions;
         private readonly List<Action<IMongoDatabase, Dictionary<Type, object>>> _builderActions;
 
         private static readonly object _lockObject = new object();
@@ -32,6 +33,7 @@ namespace MongoDB.Extensions.Context
             _registrationConventionActions = new List<Action>();
             _registrationSerializerActions = new List<Action>();
             _mongoClientSettingsActions = new List<Action<MongoClientSettings>>();
+            _databaseConfigurationActions = new List<Action<IMongoDatabase>>();
             _builderActions = new List<Action<IMongoDatabase, Dictionary<Type, object>>>();
         }
         
@@ -96,6 +98,13 @@ namespace MongoDB.Extensions.Context
             return this;
         }
 
+        public IMongoDatabaseBuilder ConfigureDatabase(Action<IMongoDatabase> configureDatabase)
+        {
+            _databaseConfigurationActions.Add(configureDatabase);
+
+            return this;
+        }
+
         internal MongoDbContextData Build()
         {
             // synchronize registration
@@ -126,6 +135,9 @@ namespace MongoDB.Extensions.Context
             // create mongo database
             IMongoDatabase mongoDatabase = mongoClient
                 .GetDatabase(_mongoOptions.DatabaseName);
+
+            // configure mongo database
+            _databaseConfigurationActions.ForEach(configure => configure(mongoDatabase));
 
             // create mongo collection builders
             var mongoCollectionBuilders = new Dictionary<Type, object>();

--- a/src/Context/Internal/MongoDbContextData.cs
+++ b/src/Context/Internal/MongoDbContextData.cs
@@ -24,7 +24,8 @@ namespace MongoDB.Extensions.Context
         public IMongoClient Client { get; }
         public IMongoDatabase Database { get; }
 
-        internal IMongoCollection<TDocument> CreateCollection<TDocument>() where TDocument : class
+        internal IMongoCollection<TDocument> CreateCollection<TDocument>() 
+            where TDocument : class
         {
             MongoCollectionBuilder<TDocument> collectionBuilder =
                 TryGetCollectionBuilder<TDocument>();
@@ -37,7 +38,8 @@ namespace MongoDB.Extensions.Context
             return collectionBuilder.Build();
         }
 
-        private MongoCollectionBuilder<TDocument> TryGetCollectionBuilder<TDocument>() where TDocument : class
+        private MongoCollectionBuilder<TDocument> TryGetCollectionBuilder<TDocument>() 
+            where TDocument : class
         {
             MongoCollectionBuilder<TDocument> collectionBuilder = null;
 

--- a/src/Context/MongoServerExtensions.cs
+++ b/src/Context/MongoServerExtensions.cs
@@ -1,0 +1,33 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace MongoDB.Extensions.Context
+{
+    public static class MongoServerExtensions
+    {
+        public static void DisableTableScan(this IMongoClient mongoClient)
+        {
+            var command = new BsonDocument { { "setParameter", 1 }, { "notablescan", 1 } };
+
+            mongoClient.GetDatabase("admin").RunCommand<BsonDocument>(command);
+        }
+        
+        public static bool IsTableScanDisabled(this IMongoClient mongoClient)
+        {
+            var getNoTableScanCommand =
+                new BsonDocument { { "getParameter", 1 }, { "notablescan", 1 } };
+
+            BsonDocument parameterResult = mongoClient.GetDatabase("admin")
+                .RunCommand<BsonDocument>(getNoTableScanCommand);
+
+            BsonElement notablescanElement = parameterResult.GetElement("notablescan");
+            
+            if(bool.TryParse(notablescanElement.Value.ToString(), out bool isDisabled))
+            {
+                return isDisabled;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Implemented an function to disable the table scan of MongoDB. 
This "notablescan" option is valid for the entire vserver, not only for one database. (Design by MongoDB)
