### PR TITLE
MongoDbContext initialization improvements

### DIFF
--- a/src/Context.Tests/MongoDbContextTests.cs
+++ b/src/Context.Tests/MongoDbContextTests.cs
@@ -47,7 +47,7 @@ namespace MongoDB.Extensions.Context.Tests
         }
 
         [Fact]
-        public void Constructor_DatabaseAccess_InitializationExecuted()
+        public void Constructor_Database_InitializationExecuted()
         {
             // Arrange
             var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
@@ -73,7 +73,7 @@ namespace MongoDB.Extensions.Context.Tests
         }
 
         [Fact]
-        public void Constructor_ClientAccess_InitializationExecuted()
+        public void Constructor_Client_InitializationExecuted()
         {
             // Arrange
             var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
@@ -86,7 +86,7 @@ namespace MongoDB.Extensions.Context.Tests
         }
 
         [Fact]
-        public void Constructor_ClientAccess_InitializationNotExecuted()
+        public void Constructor_MongoOptions_InitializationNotExecuted()
         {
             // Arrange
             var testMongoDbContext = new TestMongoDbContext(_mongoOptions);

--- a/src/Context.Tests/MongoDbContextTests.cs
+++ b/src/Context.Tests/MongoDbContextTests.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using Squadron;
 using Xunit;
 
@@ -22,36 +23,52 @@ namespace MongoDB.Extensions.Context.Tests
         #region Constructor Tests
 
         [Fact]
-        public void Constructor_AutoInitializeDefault_InitializationExecuted()
+        public void Constructor_DatabaseAccess_InitializationExecuted()
         {
             // Arrange
-            
-            // Act
             var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
 
-            // Assert
-            Assert.True(testMongoDbContext.IsInitialized);
-        }
-
-        [Fact]
-        public void Constructor_AutoInitializeManual_InitializationExecuted()
-        {
-            // Arrange
-            
             // Act
-            var testMongoDbContext = new TestMongoDbContext(_mongoOptions, true);
+            _ = testMongoDbContext.Database;
 
             // Assert
             Assert.True(testMongoDbContext.IsInitialized);
         }
 
         [Fact]
-        public void Constructor_NoInitializeManual_InitializationExecuted()
+        public void Constructor_CreateCollection_InitializationExecuted()
         {
             // Arrange
+            var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
 
             // Act
-            var testMongoDbContext = new TestMongoDbContext(_mongoOptions, false);
+            testMongoDbContext.CreateCollection<BsonDocument>();
+
+            // Assert
+            Assert.True(testMongoDbContext.IsInitialized);
+        }
+
+        [Fact]
+        public void Constructor_ClientAccess_InitializationExecuted()
+        {
+            // Arrange
+            var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
+
+            // Act
+            _ = testMongoDbContext.Client;
+
+            // Assert
+            Assert.True(testMongoDbContext.IsInitialized);
+        }
+
+        [Fact]
+        public void Constructor_ClientAccess_InitializationNotExecuted()
+        {
+            // Arrange
+            var testMongoDbContext = new TestMongoDbContext(_mongoOptions);
+
+            // Act
+            _ = testMongoDbContext.MongoOptions;
 
             // Assert
             Assert.False(testMongoDbContext.IsInitialized);
@@ -64,11 +81,6 @@ namespace MongoDB.Extensions.Context.Tests
         private class TestMongoDbContext : MongoDbContext
         {
             public TestMongoDbContext(MongoOptions mongoOptions) : base(mongoOptions)
-            {
-            }
-
-            public TestMongoDbContext(MongoOptions mongoOptions, bool enableAutoInit) 
-                : base(mongoOptions, enableAutoInit)
             {
             }
 

--- a/src/Context.Tests/MongoDbContextTests.cs
+++ b/src/Context.Tests/MongoDbContextTests.cs
@@ -23,6 +23,30 @@ namespace MongoDB.Extensions.Context.Tests
         #region Constructor Tests
 
         [Fact]
+        public void Constructor_AutoInitializeManual_InitializationExecuted()
+        {
+            // Arrange
+
+            // Act
+            var testMongoDbContext = new TestMongoDbContext(_mongoOptions, true);
+
+            // Assert
+            Assert.True(testMongoDbContext.IsInitialized);
+        }
+
+        [Fact]
+        public void Constructor_NoInitializeManual_InitializationExecuted()
+        {
+            // Arrange
+
+            // Act
+            var testMongoDbContext = new TestMongoDbContext(_mongoOptions, false);
+
+            // Assert
+            Assert.False(testMongoDbContext.IsInitialized);
+        }
+
+        [Fact]
         public void Constructor_DatabaseAccess_InitializationExecuted()
         {
             // Arrange
@@ -81,6 +105,11 @@ namespace MongoDB.Extensions.Context.Tests
         private class TestMongoDbContext : MongoDbContext
         {
             public TestMongoDbContext(MongoOptions mongoOptions) : base(mongoOptions)
+            {
+            }
+
+            public TestMongoDbContext(MongoOptions mongoOptions, bool enableAutoInit)
+                : base(mongoOptions, enableAutoInit)
             {
             }
 

--- a/src/Context/MongoDbContext.cs
+++ b/src/Context/MongoDbContext.cs
@@ -9,14 +9,25 @@ namespace MongoDB.Extensions.Context
 
         private readonly object _lockObject = new object();
 
-        protected MongoDbContext(MongoOptions mongoOptions)
+        public MongoDbContext(MongoOptions mongoOptions) : this(mongoOptions, false)
+        {
+        }
+
+        [Obsolete]
+        public MongoDbContext(MongoOptions mongoOptions, bool enableAutoInitialize)
         {
             if (mongoOptions == null)
-            {
                 throw new ArgumentNullException(nameof(mongoOptions));
-            }
 
-            MongoOptions = mongoOptions.Validate();
+            mongoOptions.Validate();
+
+            MongoOptions = mongoOptions;
+
+            // This initialization should be removed and switched to Lazy initialization.
+            if (enableAutoInitialize)
+            {
+                Initialize(mongoOptions);
+            }
         }
 
         public IMongoClient Client
@@ -49,6 +60,12 @@ namespace MongoDB.Extensions.Context
         protected abstract void OnConfiguring(IMongoDatabaseBuilder mongoDatabaseBuilder);
 
         private void EnsureInitialized()
+        {
+            Initialize(MongoOptions);
+        }
+
+        [Obsolete]
+        protected void Initialize(MongoOptions mongoOptions)
         {
             if(_mongoDbContextData == null)
             {

--- a/src/Context/MongoDbContext.cs
+++ b/src/Context/MongoDbContext.cs
@@ -39,7 +39,8 @@ namespace MongoDB.Extensions.Context
 
         public MongoOptions MongoOptions { get; }
         
-        public IMongoCollection<TDocument> CreateCollection<TDocument>() where TDocument : class
+        public IMongoCollection<TDocument> CreateCollection<TDocument>()
+            where TDocument : class
         {
             EnsureInitialized();
             return _mongoDbContextData.CreateCollection<TDocument>();
@@ -47,7 +48,7 @@ namespace MongoDB.Extensions.Context
         
         protected abstract void OnConfiguring(IMongoDatabaseBuilder mongoDatabaseBuilder);
 
-        internal void EnsureInitialized()
+        private void EnsureInitialized()
         {
             if(_mongoDbContextData == null)
             {


### PR DESCRIPTION
The MongoDbContext initialization is by default done in ctor and for later initialization the client must do some extra work for using DI in ctor.

e.g.:

```csharp
public class MyDbContext : MongoDbContext
{
   private readonly IMyService _service;
   public MyDbContext(MongoOptions options, IMyService service)
      : base(options)
   {
      _service = service;
   }
   protected override void OnConfiguring(IMongoDatabaseBuilder builder)
   {
      // do some stuff with _service   
   }
}
```

In order to use the `_service` in `OnConfiguring` we have to postpone the initialization otherwise our `_service` will be null when `OnConfiguring` is called.