### PR TITLE
Fixed mongodb profiling extensions

### DIFF
--- a/src/Prime.Extensions.Tests/MongoDatabaseExtensionsTests.cs
+++ b/src/Prime.Extensions.Tests/MongoDatabaseExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace MongoDB.Prime.Extensions.Tests
             _mongoDatabase.EnableProfiling();
 
             // Assert
-            var profileStatusCommand = new BsonDocument("profile", BsonValue.Create(null));
+            var profileStatusCommand = new BsonDocument("profile", -1);
             BsonDocument result = _mongoDatabase.RunCommand<BsonDocument>(profileStatusCommand);
 
             Assert.Equal(
@@ -42,7 +42,7 @@ namespace MongoDB.Prime.Extensions.Tests
             _mongoDatabase.EnableProfiling(ProfileLevel.All);
 
             // Assert
-            var profileStatusCommand = new BsonDocument("profile", BsonValue.Create(null));
+            var profileStatusCommand = new BsonDocument("profile", -1);
             BsonDocument result = _mongoDatabase.RunCommand<BsonDocument>(profileStatusCommand);
 
             Assert.Equal(
@@ -59,7 +59,7 @@ namespace MongoDB.Prime.Extensions.Tests
             _mongoDatabase.EnableProfiling(ProfileLevel.SlowOperationsOnly);
 
             // Assert
-            var profileStatusCommand = new BsonDocument("profile", BsonValue.Create(null));
+            var profileStatusCommand = new BsonDocument("profile", -1);
             BsonDocument result = _mongoDatabase.RunCommand<BsonDocument>(profileStatusCommand);
 
             Assert.Equal(
@@ -76,7 +76,7 @@ namespace MongoDB.Prime.Extensions.Tests
             _mongoDatabase.EnableProfiling(ProfileLevel.Off);
 
             // Assert
-            var profileStatusCommand = new BsonDocument("profile", BsonValue.Create(null));
+            var profileStatusCommand = new BsonDocument("profile", -1);
             BsonDocument result = _mongoDatabase.RunCommand<BsonDocument>(profileStatusCommand);
 
             Assert.Equal(

--- a/src/Prime.Extensions/MongoDatabaseExtensions.cs
+++ b/src/Prime.Extensions/MongoDatabaseExtensions.cs
@@ -17,11 +17,16 @@ namespace MongoDB.Prime.Extensions
 
         public static ProfilingStatus GetProfilingStatus(this IMongoDatabase mongoDatabase)
         {
-            var profileStatusCommand = new BsonDocument("profile", BsonValue.Create(null));
+            var profileStatusCommand = new BsonDocument("profile", -1);
 
             BsonDocument profileBsonDocument =
                 mongoDatabase.RunCommand<BsonDocument>(profileStatusCommand);
 
+            return CreateProfilingStatus(profileBsonDocument);
+        }
+
+        private static ProfilingStatus CreateProfilingStatus(BsonDocument profileBsonDocument)
+        {
             return new ProfilingStatus(
                 level: (ProfileLevel)profileBsonDocument["was"].AsInt32,
                 slowMs: profileBsonDocument["slowms"].AsInt32,
@@ -31,7 +36,7 @@ namespace MongoDB.Prime.Extensions
 
         public static IMongoCollection<TDocument> GetCollection<TDocument>(
             this IMongoDatabase mongoDatabase,
-            MongoCollectionSettings settings = null)
+            MongoCollectionSettings? settings = null)
         {
             return mongoDatabase.GetCollection<TDocument>(typeof(TDocument).Name, settings);
         }


### PR DESCRIPTION
The get profiling status did not work anymore with MongoDB 5.0. 
