### PR TITLE
Introduce MongoDB.Extensions.Migration 

### DIFF
--- a/samples/Migration/Customer.cs
+++ b/samples/Migration/Customer.cs
@@ -1,0 +1,8 @@
+using MongoDB.Extensions.Migration;
+
+namespace Migration;
+
+public record Customer(string Id, string Name) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/samples/Migration/ExampleMigration.cs
+++ b/samples/Migration/ExampleMigration.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
+
+namespace Migration;
+
+public class ExampleMigration : IMigration
+{
+    public int Version => 1;
+
+    public void Up(BsonDocument document)
+    {
+        document["Name"] += " Migrated up to 1";
+    }
+
+    public void Down(BsonDocument document)
+    {
+        document["Name"] += " Migrated down to 0";
+    }
+}

--- a/samples/Migration/Migration.csproj
+++ b/samples/Migration/Migration.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="2.15.1" />
+    <PackageReference Include="MongoDB.Extensions.Migration" Version="1.3.0-preview1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Migration/Program.cs
+++ b/samples/Migration/Program.cs
@@ -10,9 +10,10 @@ builder.Services
 
 var app = builder.Build();
 
-app.UseMongoMigration(m => m.ForEntity<Customer>(e => e
-    .AtVersion(1)
-    .WithMigration(new ExampleMigration())));
+app.UseMongoMigration(m => m
+    .ForEntity<Customer>(e => e
+        .AtVersion(1)
+        .WithMigration(new ExampleMigration())));
 
 app.MapGet("/customer/{id}", (string id, Repository repo) => repo.GetAsync(id));
 app.MapPost("/customer/", (Customer customer, Repository repo) => repo.AddAsync(customer));

--- a/samples/Migration/Program.cs
+++ b/samples/Migration/Program.cs
@@ -1,0 +1,20 @@
+using Migration;
+using MongoDB.Extensions.Migration;
+using MongoDB.Driver;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddSingleton(_ => new MongoClient("mongodb://localhost:27017"))
+    .AddTransient<Repository>();
+
+var app = builder.Build();
+
+app.UseMongoMigration(m => m.ForEntity<Customer>(e => e
+    .AtVersion(1)
+    .WithMigration(new ExampleMigration())));
+
+app.MapGet("/customer/{id}", (string id, Repository repo) => repo.GetAsync(id));
+app.MapPost("/customer/", (Customer customer, Repository repo) => repo.AddAsync(customer));
+
+app.Run();

--- a/samples/Migration/Repository.cs
+++ b/samples/Migration/Repository.cs
@@ -1,0 +1,20 @@
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+
+namespace Migration;
+
+public class Repository
+{
+    private readonly IMongoCollection<Customer> _collection;
+
+    public Repository(MongoClient client)
+    {
+        var database = client.GetDatabase("Example1");
+        _collection = database.GetCollection<Customer>("customer");
+    }
+
+    public Task AddAsync(Customer customer) => _collection.InsertOneAsync(customer);
+
+    public Task<Customer> GetAsync(string id) => _collection.AsQueryable()
+        .SingleOrDefaultAsync(c => c.Id == id);
+}

--- a/samples/Migration/appsettings.Development.json
+++ b/samples/Migration/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/Migration/appsettings.json
+++ b/samples/Migration/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/MongoDB.Extensions.Samples.sln
+++ b/samples/MongoDB.Extensions.Samples.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SimpleBlog", "SimpleBlog", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Host", "Context\Host\Host.csproj", "{0CCED088-DBB6-4DA2-8DFC-D9968EEBB9FA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Migration", "Migration\Migration.csproj", "{8226313B-FAC9-4D0F-AEE8-424DD310BBFB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{0CCED088-DBB6-4DA2-8DFC-D9968EEBB9FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CCED088-DBB6-4DA2-8DFC-D9968EEBB9FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CCED088-DBB6-4DA2-8DFC-D9968EEBB9FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8226313B-FAC9-4D0F-AEE8-424DD310BBFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8226313B-FAC9-4D0F-AEE8-424DD310BBFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8226313B-FAC9-4D0F-AEE8-424DD310BBFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8226313B-FAC9-4D0F-AEE8-424DD310BBFB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Migration.Tests/Integration/Scenario1/MigrateDownTests.cs
+++ b/src/Migration.Tests/Integration/Scenario1/MigrateDownTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Extensions.Migration;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using Squadron;
+using Xunit;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+[Collection("SharedMongoDbCollection")]
+public class MigrateDownTests
+{
+    readonly IMongoCollection<TestEntityForDown> _typedCollection;
+    readonly IMongoCollection<BsonDocument> _untypedCollection;
+
+    public MigrateDownTests(MongoResource resource)
+    {
+        RegisterMongoMigrations();
+        IMongoDatabase database = resource.Client.GetDatabase("Scenario1-down");
+        _typedCollection = database.GetCollection<TestEntityForDown>("TestEntityForDown");
+        _untypedCollection = database.GetCollection<BsonDocument>("TestEntityForDown");
+    }
+
+    static void RegisterMongoMigrations()
+    {
+        ILoggerFactory loggerFactory = LoggerFactory.Create(_ => { });
+
+        MigrationOption options = new MigrationOptionBuilder()
+            .ForEntity<TestEntityForDown>(o => o.AtVersion(0)
+                .WithMigration(new TestMigration1())
+                .WithMigration(new TestMigration2())
+                .WithMigration(new TestMigration3()))
+            .Build();
+        var context = new MigrationContext(options, loggerFactory);
+
+        BsonSerializer.RegisterSerializationProvider(new MigrationSerializerProvider(context));
+    }
+
+    [Fact]
+    public async Task Scenario1_AddRetrieve_NoMigration()
+    {
+        // Arrange
+        const string input = "Bar";
+        await _typedCollection.InsertOneAsync(new TestEntityForDown("1", input, 1));
+
+        // Act
+        TestEntityForDown result = await _typedCollection.AsQueryable()
+            .SingleOrDefaultAsync(c => c.Id == "1");
+
+        // Assert
+        result.Foo.Should().Be(input);
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveAtVersion3_MigratedDownTo0()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+        { ["_id"] = "id0", ["Foo"] = "Bar", ["Version"] = 3 }));
+
+        // Act
+        TestEntityForDown result = await _typedCollection.AsQueryable()
+            .SingleOrDefaultAsync(c => c.Id == "id0");
+
+        // Assert
+        result.Foo.Should().Be("Bar Migrated Down to 2 Migrated Down to 1 Migrated Down to 0");
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveAtVersion2_MigratedToVersion3()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+        { ["_id"] = "id1", ["Foo"] = "Bar", ["Version"] = 1 }));
+
+        // Act
+        TestEntityForDown result = await _typedCollection.AsQueryable()
+            .SingleOrDefaultAsync(c => c.Id == "id1");
+
+        // Assert
+        result.Foo.Should().Be("Bar Migrated Down to 0");
+    }
+
+}

--- a/src/Migration.Tests/Integration/Scenario1/MigrateDownTests.cs
+++ b/src/Migration.Tests/Integration/Scenario1/MigrateDownTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using MongoDB.Extensions.Migration;
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
@@ -28,15 +28,13 @@ public class MigrateDownTests
 
     static void RegisterMongoMigrations()
     {
-        ILoggerFactory loggerFactory = LoggerFactory.Create(_ => { });
-
         MigrationOption options = new MigrationOptionBuilder()
             .ForEntity<TestEntityForDown>(o => o.AtVersion(0)
                 .WithMigration(new TestMigration1())
                 .WithMigration(new TestMigration2())
                 .WithMigration(new TestMigration3()))
             .Build();
-        var context = new MigrationContext(options, loggerFactory);
+        var context = new MigrationContext(options, NullLoggerFactory.Instance);
 
         BsonSerializer.RegisterSerializationProvider(new MigrationSerializerProvider(context));
     }
@@ -46,7 +44,7 @@ public class MigrateDownTests
     {
         // Arrange
         const string input = "Bar";
-        await _typedCollection.InsertOneAsync(new TestEntityForDown("1", input, 1));
+        await _typedCollection.InsertOneAsync(new TestEntityForDown("1", input));
 
         // Act
         TestEntityForDown result = await _typedCollection.AsQueryable()

--- a/src/Migration.Tests/Integration/Scenario1/MigrateUpTests.cs
+++ b/src/Migration.Tests/Integration/Scenario1/MigrateUpTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MongoDB.Extensions.Migration;
 using FluentAssertions;
@@ -66,6 +66,34 @@ public class MigrateUpTests
 
         // Assert
         result.Foo.Should().Be("Bar Migrated Up to 1 Migrated Up to 2 Migrated Up to 3");
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveWithoutVersion_MigratedToNewestVersion()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+            { ["_id"] = "id5", ["Foo"] = "Bar" }));
+
+        // Act
+        TestEntityForUp result = await _typedCollection.AsQueryable().SingleOrDefaultAsync(c => c.Id == "id0");
+
+        // Assert
+        result.Foo.Should().Be("Bar Migrated Up to 1 Migrated Up to 2 Migrated Up to 3");
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveAtNewUnknownVersion_NoMigration()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+            { ["_id"] = "id4", ["Foo"] = "Bar", ["Version"] = 4 }));
+
+        // Act
+        TestEntityForUp result = await _typedCollection.AsQueryable().SingleOrDefaultAsync(c => c.Id == "id0");
+
+        // Assert
+        result.Foo.Should().Be("Bar");
     }
 
     [Fact]

--- a/src/Migration.Tests/Integration/Scenario1/MigrateUpTests.cs
+++ b/src/Migration.Tests/Integration/Scenario1/MigrateUpTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Extensions.Migration;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using Xunit;
+using MongoDB.Driver.Linq;
+using Squadron;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+[Collection("SharedMongoDbCollection")]
+public class MigrateUpTests
+{
+    readonly IMongoCollection<TestEntityForUp> _typedCollection;
+    readonly IMongoCollection<BsonDocument> _untypedCollection;
+
+    public MigrateUpTests(MongoResource resource)
+    {
+        RegisterMongoMigrations();
+        var database = resource.Client.GetDatabase("Scenario1-up");
+        _typedCollection = database.GetCollection<TestEntityForUp>("TestEntityForUp");
+        _untypedCollection = database.GetCollection<BsonDocument>("TestEntityForUp");
+    }
+
+    static void RegisterMongoMigrations()
+    {
+        var loggerFactory = LoggerFactory.Create(_ => { });
+
+        var options = new MigrationOptionBuilder().ForEntity<TestEntityForUp>(o => o
+                .WithMigration(new TestMigration1())
+                .WithMigration(new TestMigration2())
+                .WithMigration(new TestMigration3()))
+            .Build();
+        var context = new MigrationContext(options, loggerFactory);
+
+        BsonSerializer.RegisterSerializationProvider(new MigrationSerializerProvider(context));
+    }
+
+    [Fact]
+    public async Task Scenario1_AddRetrieve_NoMigration()
+    {
+        // Arrange
+        const string input = "Bar";
+        await _typedCollection.InsertOneAsync(new TestEntityForUp("1", input, 1));
+
+        // Act
+        var result = await _typedCollection.AsQueryable().SingleOrDefaultAsync(c => c.Id == "1");
+
+        // Assert
+        result.Foo.Should().Be(input);
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveAtVersion0_MigratedToNewestVersion()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+        { ["_id"] = "id0", ["Foo"] = "Bar", ["Version"] = 0 }));
+
+        // Act
+        TestEntityForUp result = await _typedCollection.AsQueryable().SingleOrDefaultAsync(c => c.Id == "id0");
+
+        // Assert
+        result.Foo.Should().Be("Bar Migrated Up to 1 Migrated Up to 2 Migrated Up to 3");
+    }
+
+    [Fact]
+    public async Task Scenario1_RetrieveAtVersion2_MigratedToVersion3()
+    {
+        // Arrange
+        await _untypedCollection.InsertOneAsync(new BsonDocument(new Dictionary<string, object>
+        { ["_id"] = "id1", ["Foo"] = "Bar", ["Version"] = 2 }));
+
+        // Act
+        TestEntityForUp result = await _typedCollection.AsQueryable().SingleOrDefaultAsync(c => c.Id == "id1");
+
+        // Assert
+        result.Foo.Should().Be("Bar Migrated Up to 3");
+    }
+}

--- a/src/Migration.Tests/Integration/Scenario1/TestEntityForDown.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestEntityForDown.cs
@@ -1,0 +1,8 @@
+﻿using MongoDB.Extensions.Migration;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+public record TestEntityForDown(string Id, string Foo, int Version) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Integration/Scenario1/TestEntityForDown.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestEntityForDown.cs
@@ -1,8 +1,8 @@
-﻿using MongoDB.Extensions.Migration;
+using MongoDB.Extensions.Migration;
 
 namespace MongoMigrationTest.Integration.Scenario1;
 
-public record TestEntityForDown(string Id, string Foo, int Version) : IVersioned
+public record TestEntityForDown(string Id, string Foo) : IVersioned
 {
     public int Version { get; set; }
 }

--- a/src/Migration.Tests/Integration/Scenario1/TestEntityForUp.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestEntityForUp.cs
@@ -1,0 +1,8 @@
+﻿using MongoDB.Extensions.Migration;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+public record TestEntityForUp(string Id, string Foo, int Version) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Integration/Scenario1/TestEntityForUp.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestEntityForUp.cs
@@ -1,8 +1,8 @@
-﻿using MongoDB.Extensions.Migration;
+using MongoDB.Extensions.Migration;
 
 namespace MongoMigrationTest.Integration.Scenario1;
 
-public record TestEntityForUp(string Id, string Foo, int Version) : IVersioned
+public record TestEntityForUp(string Id, string Foo) : IVersioned
 {
     public int Version { get; set; }
 }

--- a/src/Migration.Tests/Integration/Scenario1/TestMigration1.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestMigration1.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Extensions.Migration;
+using MongoDB.Bson;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+public class TestMigration1 : IMigration
+{
+    public int Version { get; } = 1;
+
+    public void Up(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Up to 1";
+    }
+
+    public void Down(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Down to 0";
+    }
+}

--- a/src/Migration.Tests/Integration/Scenario1/TestMigration2.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestMigration2.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Extensions.Migration;
+using MongoDB.Bson;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+public class TestMigration2 : IMigration
+{
+    public int Version { get; } = 2;
+
+    public void Up(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Up to 2";
+    }
+
+    public void Down(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Down to 1";
+    }
+}

--- a/src/Migration.Tests/Integration/Scenario1/TestMigration3.cs
+++ b/src/Migration.Tests/Integration/Scenario1/TestMigration3.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Extensions.Migration;
+using MongoDB.Bson;
+
+namespace MongoMigrationTest.Integration.Scenario1;
+
+public class TestMigration3 : IMigration
+{
+    public int Version { get; } = 3;
+
+    public void Up(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Up to 3";
+    }
+
+    public void Down(BsonDocument document)
+    {
+        document["Foo"] += " Migrated Down to 2";
+    }
+}

--- a/src/Migration.Tests/Integration/Scenario2/TestEntityForDown.cs
+++ b/src/Migration.Tests/Integration/Scenario2/TestEntityForDown.cs
@@ -1,0 +1,8 @@
+using MongoDB.Extensions.Migration;
+
+namespace MongoMigrationTest.Integration.Scenario2;
+
+public record TestEntityForDown(string Id, string Foo) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Integration/Scenario2/TestEntityForUp.cs
+++ b/src/Migration.Tests/Integration/Scenario2/TestEntityForUp.cs
@@ -1,0 +1,8 @@
+using MongoDB.Extensions.Migration;
+
+namespace MongoMigrationTest.Integration.Scenario2;
+
+public record TestEntityForUp(string Id, string Foo) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Integration/SharedMongoDbCollection.cs
+++ b/src/Migration.Tests/Integration/SharedMongoDbCollection.cs
@@ -1,0 +1,9 @@
+﻿using Squadron;
+using Xunit;
+
+namespace MongoMigrationTest.Integration;
+
+[CollectionDefinition("SharedMongoDbCollection")]
+public class SharedMongoDbCollection : ICollectionFixture<MongoResource>
+{
+}

--- a/src/Migration.Tests/Migration.Tests.csproj
+++ b/src/Migration.Tests/Migration.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCTestProjectProps)" Condition="Exists('$(CCTestProjectProps)')" />
+
+  <PropertyGroup>
+    <AssemblyName>Migration.Tests</AssemblyName>
+    <RootNamespace>Migration.Tests</RootNamespace>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Migration\Migration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Migration.Tests/TestMigration1.cs
+++ b/src/Migration.Tests/TestMigration1.cs
@@ -1,7 +1,7 @@
-﻿using MongoDB.Extensions.Migration;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
 
-namespace MongoMigrationTest.Integration.Scenario1;
+namespace Migration.Tests;
 
 public class TestMigration1 : IMigration
 {

--- a/src/Migration.Tests/TestMigration2.cs
+++ b/src/Migration.Tests/TestMigration2.cs
@@ -1,7 +1,7 @@
-﻿using MongoDB.Extensions.Migration;
 using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
 
-namespace MongoMigrationTest.Integration.Scenario1;
+namespace Migration.Tests;
 
 public class TestMigration2 : IMigration
 {

--- a/src/Migration.Tests/TestMigration3.cs
+++ b/src/Migration.Tests/TestMigration3.cs
@@ -1,7 +1,7 @@
-﻿using MongoDB.Extensions.Migration;
 using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
 
-namespace MongoMigrationTest.Integration.Scenario1;
+namespace Migration.Tests;
 
 public class TestMigration3 : IMigration
 {

--- a/src/Migration.Tests/Unit/EntityOptionBuilderTests.cs
+++ b/src/Migration.Tests/Unit/EntityOptionBuilderTests.cs
@@ -57,8 +57,3 @@ public class EntityOptionBuilderTests
         action.Should().Throw<InvalidConfigurationException>();
     }
 }
-
-record TestEntity(int Id) : IVersioned
-{
-    public int Version { get; set; }
-}

--- a/src/Migration.Tests/Unit/EntityOptionBuilderTests.cs
+++ b/src/Migration.Tests/Unit/EntityOptionBuilderTests.cs
@@ -1,0 +1,64 @@
+using System;
+using FluentAssertions;
+using MongoDB.Extensions.Migration;
+using Xunit;
+
+namespace Migration.Tests.Unit;
+
+public class EntityOptionBuilderTests
+{
+    [Fact]
+    public void EntityOptionBuilder_AtVersionNotSet_SetToLatestVersion()
+    {
+        // Act
+        EntityOption entityOption = new EntityOptionBuilder<TestEntity>()
+            .WithMigration(new TestMigration1())
+            .WithMigration(new TestMigration2())
+            .Build();
+
+        // Assert
+        entityOption.CurrentVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public void EntityOptionBuilder_NoMigrationRegistered_Throws()
+    {
+        // Act
+        Action action = () => new EntityOptionBuilder<TestEntity>().Build();
+
+        // Assert
+        action.Should().Throw<InvalidConfigurationException>();
+    }
+
+    [Fact]
+    public void EntityOptionBuilder_GabInMigrationVersions_Throws()
+    {
+        // Act
+        Action action = () => new EntityOptionBuilder<TestEntity>()
+                .WithMigration(new TestMigration3())
+                .WithMigration(new TestMigration1())
+                .Build();
+
+        // Assert
+        action.Should().Throw<InvalidConfigurationException>();
+    }
+
+    [Fact]
+    public void EntityOptionBuilder_AtVersionHasNoMigrationMigrationVersions_Throws()
+    {
+        // Act
+        Action action = () => new EntityOptionBuilder<TestEntity>()
+            .WithMigration(new TestMigration2())
+            .WithMigration(new TestMigration1())
+            .AtVersion(3)
+            .Build();
+
+        // Assert
+        action.Should().Throw<InvalidConfigurationException>();
+    }
+}
+
+record TestEntity(int Id) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Unit/MigrationOptionBuilderTests.cs
+++ b/src/Migration.Tests/Unit/MigrationOptionBuilderTests.cs
@@ -1,0 +1,23 @@
+using System;
+using FluentAssertions;
+using MongoDB.Extensions.Migration;
+using Xunit;
+
+namespace Migration.Tests.Unit;
+
+public class MigrationOptionBuilderTests
+{
+    [Fact]
+    public void MigrationOptionBuilder_RegisterEntityTwice_Throws()
+    {
+        // Arrange
+        var builder = new MigrationOptionBuilder();
+        builder.ForEntity<TestEntity>(b => b.WithMigration(new TestMigration()));
+
+        // Act
+        Action action = () => builder.ForEntity<TestEntity>(b => b.WithMigration(new TestMigration()));
+
+        // Assert
+        action.Should().Throw<InvalidConfigurationException>();
+    }
+}

--- a/src/Migration.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/Migration.Tests/Unit/MigrationRunnerTests.cs
@@ -10,26 +10,6 @@ namespace Migration.Tests.Unit;
 
 public class MigrationRunnerTests
 {
-    record TestEntity(string Id, int Version) : IVersioned
-    {
-        public int Version { get; set; } = Version;
-    };
-
-    public class TestMigration : IMigration
-    {
-        public int Version { get; } = 1;
-
-        public void Up(BsonDocument document)
-        {
-            throw new Exception();
-        }
-
-        public void Down(BsonDocument document)
-        {
-            throw new Exception();
-        }
-    }
-
     [Fact]
     public void MigrationRunner_MigrationUpThrows_Catches()
     {

--- a/src/Migration.Tests/Unit/MigrationRunnerTests.cs
+++ b/src/Migration.Tests/Unit/MigrationRunnerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
+using Xunit;
+
+namespace Migration.Tests.Unit;
+
+public class MigrationRunnerTests
+{
+    record TestEntity(string Id, int Version) : IVersioned
+    {
+        public int Version { get; set; } = Version;
+    };
+
+    public class TestMigration : IMigration
+    {
+        public int Version { get; } = 1;
+
+        public void Up(BsonDocument document)
+        {
+            throw new Exception();
+        }
+
+        public void Down(BsonDocument document)
+        {
+            throw new Exception();
+        }
+    }
+
+    [Fact]
+    public void MigrationRunner_MigrationUpThrows_Catches()
+    {
+        // Arrange
+        var runner = new MigrationRunner<TestEntity>(new EntityContext(
+            new EntityOptionBuilder<TestEntity>().WithMigration(new TestMigration())
+                .Build(),
+            new NullLoggerFactory()));
+        var document = new Dictionary<string, object> { ["Version"] = 1, ["_id"] = 1 };
+
+        // Act
+        Action action = () => runner.Run(new BsonDocument(document));
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MigrationRunner_MigrationDownThrows_Catches()
+    {
+        // Arrange
+        var runner = new MigrationRunner<TestEntity>(new EntityContext(
+            new EntityOptionBuilder<TestEntity>().WithMigration(new TestMigration()).AtVersion(0)
+                .Build(),
+            new NullLoggerFactory()));
+        var document = new Dictionary<string, object> { ["Version"] = 1, ["_id"] = 1 };
+
+        // Act
+        Action action = () => runner.Run(new BsonDocument(document));
+        
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+}

--- a/src/Migration.Tests/Unit/TestEntity.cs
+++ b/src/Migration.Tests/Unit/TestEntity.cs
@@ -1,0 +1,8 @@
+using MongoDB.Extensions.Migration;
+
+namespace Migration.Tests.Unit;
+
+record TestEntity(int Id) : IVersioned
+{
+    public int Version { get; set; }
+}

--- a/src/Migration.Tests/Unit/TestMigration.cs
+++ b/src/Migration.Tests/Unit/TestMigration.cs
@@ -1,0 +1,20 @@
+using System;
+using MongoDB.Bson;
+using MongoDB.Extensions.Migration;
+
+namespace Migration.Tests.Unit;
+
+public class TestMigration : IMigration
+{
+    public int Version { get; } = 1;
+
+    public void Up(BsonDocument document)
+    {
+        throw new Exception();
+    }
+
+    public void Down(BsonDocument document)
+    {
+        throw new Exception();
+    }
+}

--- a/src/Migration/Builders/EntityOptionBuilder.cs
+++ b/src/Migration/Builders/EntityOptionBuilder.cs
@@ -50,7 +50,7 @@ public class EntityOptionBuilder<T> where T : IVersioned
                 $"There is no migration for version {_atVersion} for entity {typeof(T).Name}");
         }
 
-        for (var i = _migrations.First().Version + 1; i < _migrations.Count; i++)
+        for (var i = 1; i < _migrations.Count; i++)
         {
             if (_migrations[i - 1].Version + 1 != _migrations[i].Version)
             {

--- a/src/Migration/Builders/EntityOptionBuilder.cs
+++ b/src/Migration/Builders/EntityOptionBuilder.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MongoDB.Extensions.Migration;
+
+public class EntityOptionBuilder<T> where T : IVersioned
+{
+    private int? _atVersion;
+    private readonly List<IMigration> _migrations = new();
+
+    /// <summary>
+    /// Set the current Version of the data which is suitable for the application.
+    /// If not set the newest Version is used.
+    /// </summary>
+    public EntityOptionBuilder<T> AtVersion(int atVersion)
+    {
+        _atVersion = atVersion;
+        return this;
+    }
+
+    /// <summary>
+    /// Register a migration for an entity. The versions of the migrations must start at 1 and be
+    /// continuously incremented without a gap
+    /// </summary>
+    public EntityOptionBuilder<T> WithMigration(IMigration migration)
+    {
+        _migrations.Add(migration);
+        return this;
+    }
+
+    public EntityOption Build()
+    {
+        if (_migrations.Count == 0)
+        {
+            throw new BuilderNotInitializedException(
+                "Please register at least one migration using the WithMigration method");
+        }
+
+        _migrations.Sort((x, y) => x.Version.CompareTo(y.Version));
+
+        _atVersion ??= _migrations.Last().Version;
+
+        // TODO: use IComparibel for this
+        if (_atVersion != 0 && _migrations.All(m => !Equals(m.Version, _atVersion)))
+        {
+            throw new InvalidConfigurationException(
+                $"There is no migration for version {_atVersion} for entity {typeof(T).Name}");
+        }
+
+        for (var i = 1; i < _migrations.Count; i++)
+        {
+            if (_migrations[i - 1].Version + 1 != _migrations[i].Version)
+            {
+                // TODO: Compare with IComparibel instead
+                throw new InvalidConfigurationException(
+                    "The versions of the migrations must be continuously incremented");
+            }
+
+        }
+
+        return new EntityOption(
+            typeof(T),
+            _atVersion.Value,
+            _migrations);
+    }
+}

--- a/src/Migration/Builders/EntityOptionBuilder.cs
+++ b/src/Migration/Builders/EntityOptionBuilder.cs
@@ -28,34 +28,35 @@ public class EntityOptionBuilder<T> where T : IVersioned
         return this;
     }
 
+    /// <summary>
+    /// Builds the EntityOption
+    /// </summary>
     public EntityOption Build()
     {
         if (_migrations.Count == 0)
         {
-            throw new BuilderNotInitializedException(
-                "Please register at least one migration using the WithMigration method");
+            throw new InvalidConfigurationException(
+                $"There must be at least one migration registered for entity {typeof(T).Name}");
         }
 
         _migrations.Sort((x, y) => x.Version.CompareTo(y.Version));
 
         _atVersion ??= _migrations.Last().Version;
 
-        // TODO: use IComparibel for this
-        if (_atVersion != 0 && _migrations.All(m => !Equals(m.Version, _atVersion)))
+        if (_atVersion != _migrations.First().Version - 1 &&
+            _migrations.All(m => !Equals(m.Version, _atVersion)))
         {
             throw new InvalidConfigurationException(
                 $"There is no migration for version {_atVersion} for entity {typeof(T).Name}");
         }
 
-        for (var i = 1; i < _migrations.Count; i++)
+        for (var i = _migrations.First().Version + 1; i < _migrations.Count; i++)
         {
             if (_migrations[i - 1].Version + 1 != _migrations[i].Version)
             {
-                // TODO: Compare with IComparibel instead
                 throw new InvalidConfigurationException(
-                    "The versions of the migrations must be continuously incremented");
+                    $"{typeof(T).Name}: Migration Versions must be continuously incremented!");
             }
-
         }
 
         return new EntityOption(

--- a/src/Migration/Builders/EntityOptionBuilder.cs
+++ b/src/Migration/Builders/EntityOptionBuilder.cs
@@ -33,7 +33,7 @@ public class EntityOptionBuilder<T> where T : IVersioned
     /// </summary>
     public EntityOption Build()
     {
-        if (_migrations.Count == 0)
+        if (!_migrations.Any())
         {
             throw new InvalidConfigurationException(
                 $"There must be at least one migration registered for entity {typeof(T).Name}");

--- a/src/Migration/Builders/MigrationOptionBuilder.cs
+++ b/src/Migration/Builders/MigrationOptionBuilder.cs
@@ -7,11 +7,17 @@ public class MigrationOptionBuilder
 {
     private readonly List<EntityOption> _entityOptions = new();
 
+    /// <summary>
+    /// Builds the MigrationOption
+    /// </summary>
     public MigrationOption Build()
     {
         return new MigrationOption(_entityOptions);
     }
 
+    /// <summary>
+    /// Register a migration for a given entity.
+    /// </summary>
     public MigrationOptionBuilder ForEntity<T>(
         Func<EntityOptionBuilder<T>, EntityOptionBuilder<T>> builderAction) where T : IVersioned
     {

--- a/src/Migration/Builders/MigrationOptionBuilder.cs
+++ b/src/Migration/Builders/MigrationOptionBuilder.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace MongoDB.Extensions.Migration;
+
+public class MigrationOptionBuilder
+{
+    private readonly List<EntityOption> _entityOptions = new();
+
+    public MigrationOption Build()
+    {
+        return new MigrationOption(_entityOptions);
+    }
+
+    public MigrationOptionBuilder ForEntity<T>(
+        Func<EntityOptionBuilder<T>, EntityOptionBuilder<T>> builderAction) where T : IVersioned
+    {
+        _entityOptions.Add(builderAction(new EntityOptionBuilder<T>()).Build());
+        return this;
+    }
+}

--- a/src/Migration/Builders/MigrationOptionBuilder.cs
+++ b/src/Migration/Builders/MigrationOptionBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MongoDB.Extensions.Migration;
 
@@ -21,6 +22,11 @@ public class MigrationOptionBuilder
     public MigrationOptionBuilder ForEntity<T>(
         Func<EntityOptionBuilder<T>, EntityOptionBuilder<T>> builderAction) where T : IVersioned
     {
+        if (_entityOptions.Any(e => e.Type == typeof(T)))
+        {
+            throw new InvalidConfigurationException(
+                $"Migrations for entity of type {typeof(T).FullName} have already been registered");
+        }
         _entityOptions.Add(builderAction(new EntityOptionBuilder<T>()).Build());
         return this;
     }

--- a/src/Migration/Contracts/IMigration.cs
+++ b/src/Migration/Contracts/IMigration.cs
@@ -1,10 +1,10 @@
-﻿using MongoDB.Bson;
+using MongoDB.Bson;
 
 namespace MongoDB.Extensions.Migration;
 
 public interface IMigration
 {
     int Version { get; }
-    public void Up(BsonDocument document);
-    public void Down(BsonDocument document);
+    void Up(BsonDocument document);
+    void Down(BsonDocument document);
 }

--- a/src/Migration/Contracts/IMigration.cs
+++ b/src/Migration/Contracts/IMigration.cs
@@ -1,0 +1,10 @@
+﻿using MongoDB.Bson;
+
+namespace MongoDB.Extensions.Migration;
+
+public interface IMigration
+{
+    int Version { get; }
+    public void Up(BsonDocument document);
+    public void Down(BsonDocument document);
+}

--- a/src/Migration/Contracts/IVersioned.cs
+++ b/src/Migration/Contracts/IVersioned.cs
@@ -1,0 +1,6 @@
+﻿namespace MongoDB.Extensions.Migration;
+
+public interface IVersioned
+{
+    int Version { get; set; }
+}

--- a/src/Migration/Exceptions/BuilderNotInitializedException.cs
+++ b/src/Migration/Exceptions/BuilderNotInitializedException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MongoDB.Extensions.Migration;
+
+public class BuilderNotInitializedException : Exception
+{
+    public BuilderNotInitializedException(string message) : base(message) { }
+}

--- a/src/Migration/Exceptions/BuilderNotInitializedException.cs
+++ b/src/Migration/Exceptions/BuilderNotInitializedException.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace MongoDB.Extensions.Migration;
-
-public class BuilderNotInitializedException : Exception
-{
-    public BuilderNotInitializedException(string message) : base(message) { }
-}

--- a/src/Migration/Exceptions/InvalidConfigurationException.cs
+++ b/src/Migration/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MongoDB.Extensions.Migration;
+
+public class InvalidConfigurationException : Exception
+{
+    public InvalidConfigurationException(string message) : base(message) { }
+}

--- a/src/Migration/Exceptions/InvalidConfigurationException.cs
+++ b/src/Migration/Exceptions/InvalidConfigurationException.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
 
 namespace MongoDB.Extensions.Migration;
 
 public class InvalidConfigurationException : Exception
 {
+    public InvalidConfigurationException() { }
     public InvalidConfigurationException(string message) : base(message) { }
+    public InvalidConfigurationException(string message, Exception innerException) :
+        base(message, innerException) { }
 }

--- a/src/Migration/Migration.csproj
+++ b/src/Migration/Migration.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCResourceProjectProps)" Condition="Exists('$(CCResourceProjectProps)')" />
+
+  <PropertyGroup>
+    <AssemblyName>MongoDB.Extensions.Migration</AssemblyName>
+    <RootNamespace>MongoDB.Extensions.Migration</RootNamespace>
+    <PackageId>MongoDB.Extensions.Migration</PackageId>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.15.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Migration/MigrationExtensions.cs
+++ b/src/Migration/MigrationExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.Extensions.Migration;
+
+public static class MigrationExtensions
+{
+    public static IApplicationBuilder UseMongoMigration(
+        this IApplicationBuilder app,
+        Func<MigrationOptionBuilder, MigrationOptionBuilder> builderAction)
+    {
+        var builder = new MigrationOptionBuilder();
+        MigrationOption options = builderAction(builder).Build();
+
+        MigrationContext context = new(
+            options,
+            app.ApplicationServices.GetRequiredService<ILoggerFactory>());
+
+        BsonSerializer.RegisterSerializationProvider(new MigrationSerializerProvider(context));
+
+        return app;
+    }
+}

--- a/src/Migration/MigrationRunner.cs
+++ b/src/Migration/MigrationRunner.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+
+namespace MongoDB.Extensions.Migration;
+
+public class MigrationRunner<T>
+{
+    private readonly ILogger<MigrationRunner<T>> _logger;
+    private const string Version = "Version";
+    private const string Id = "_id";
+    private readonly Dictionary<int, IMigration> _migrationRegistry;
+    private readonly int _currentVersion;
+
+    public MigrationRunner(EntityContext context)
+    {
+        _currentVersion = context.Option.CurrentVersion;
+        _migrationRegistry = context.Option.Migrations.ToDictionary(m => m.Version, m => m);
+        _logger = context.LoggerFactory.CreateLogger<MigrationRunner<T>>();
+    }
+
+    public void Run(BsonDocument document)
+    {
+        // TODO: Change to IComparable
+        // use BsonTypeMapper.MapToDotNetValue or BsonDocumentSerializer.Instance.Deserialize depending if it is a primitive type or not
+        // unresolved issue: To what do we default if we do not have a version, maybe null?
+        var fromVersion = document.Contains(Version) && document[Version].IsInt32 
+            ? document[Version].AsInt32
+            : 0;
+        string id = document[Id].ToString() ?? "";
+
+        MigrateUp(document, _currentVersion, fromVersion, id);
+        MigrateDown(document, _currentVersion, fromVersion, id);
+    }
+
+    private void MigrateUp(
+        BsonDocument document,
+        int toVersion,
+        int fromVersion,
+        string id)
+    {
+        for (var version = fromVersion + 1; version <= toVersion; version++)
+        {
+            try
+            {
+                IMigration migration = _migrationRegistry[version];
+                migration.Up(document);
+                document.Set(Version, version);
+                _logger.LogInformation(
+                    "Successfully Migrated {entity} with id {id} to version {version} ",
+                    typeof(T).Name,
+                    id,
+                    version);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Migration of {entity} with id {id} to version {version} failed",
+                    typeof(T).Name,
+                    id,
+                    version);
+                break;
+            }
+        }
+    }
+
+    private void MigrateDown(
+        BsonDocument document,
+        int toVersion,
+        int fromVersion,
+        string id)
+    {
+        for (var version = fromVersion; version > toVersion; version--)
+        {
+            try
+            {
+                IMigration migration = _migrationRegistry[version];
+                migration.Down(document);
+                document.Set(Version, version);
+                _logger.LogInformation(
+                    "Successfully Migrated {entity} with id {id} to version {version} ",
+                    typeof(T).Name,
+                    id,
+                    version);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Migration of {entity} with id {id} to version {version} failed",
+                    typeof(T).Name,
+                    id,
+                    version);
+                break;
+            }
+        }
+    }
+}

--- a/src/Migration/MigrationSerializer.cs
+++ b/src/Migration/MigrationSerializer.cs
@@ -1,0 +1,44 @@
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace MongoDB.Extensions.Migration;
+
+class MigrationSerializer<T> : BsonClassMapSerializer<T> where T : IVersioned
+{
+    private readonly EntityContext _context;
+    private readonly MigrationRunner<T> _migrationRunner;
+
+    public MigrationSerializer(EntityContext context) : base(BsonClassMap.LookupClassMap(typeof(T)))
+    {
+        _context = context;
+        _migrationRunner = new MigrationRunner<T>(context);
+    }
+
+
+    public override void Serialize(
+        BsonSerializationContext context,
+        BsonSerializationArgs args,
+        T value)
+    {
+        value.Version = _context.Option.CurrentVersion;
+        base.Serialize(context, args, value);
+    }
+
+    public override T Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        BsonDocument bsonDocument = BsonDocumentSerializer.Instance.Deserialize(context);
+
+        _migrationRunner.Run(bsonDocument);
+
+        var migratedContext =
+            BsonDeserializationContext.CreateRoot(new BsonDocumentReader(bsonDocument));
+
+        T entity = base.Deserialize(migratedContext, args);
+
+        entity.Version = _context.Option.CurrentVersion;
+
+        return entity;
+    }
+}

--- a/src/Migration/MigrationSerializerProvider.cs
+++ b/src/Migration/MigrationSerializerProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using MongoDB.Bson.Serialization;
+
+namespace MongoDB.Extensions.Migration;
+
+public class MigrationSerializerProvider : IBsonSerializationProvider
+{
+    private readonly MigrationContext _context;
+
+    public MigrationSerializerProvider(MigrationContext context)
+    {
+        _context = context;
+    }
+
+    public IBsonSerializer? GetSerializer(Type type)
+    {
+        EntityOption? option = _context.Option.EntityOptions.FirstOrDefault(e => e.Type == type);
+        if (option is null)
+        {
+            return null;
+        }
+
+        EntityContext entityContext = new(option, _context.LoggerFactory);
+        Type migrationSerializerDefinition = typeof(MigrationSerializer<>);
+        Type migrationSerializerType = migrationSerializerDefinition.MakeGenericType(type);
+        return (IBsonSerializer?)Activator.CreateInstance(migrationSerializerType, entityContext);
+    }
+}

--- a/src/Migration/MigrationSerializerProvider.cs
+++ b/src/Migration/MigrationSerializerProvider.cs
@@ -15,7 +15,7 @@ public class MigrationSerializerProvider : IBsonSerializationProvider
 
     public IBsonSerializer? GetSerializer(Type type)
     {
-        EntityOption? option = _context.Option.EntityOptions.FirstOrDefault(e => e.Type == type);
+        EntityOption? option = _context.Option.EntityOptions.SingleOrDefault(e => e.Type == type);
         if (option is null)
         {
             return null;

--- a/src/Migration/Models/EntityContext.cs
+++ b/src/Migration/Models/EntityContext.cs
@@ -1,0 +1,5 @@
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.Extensions.Migration;
+
+public record EntityContext(EntityOption Option, ILoggerFactory LoggerFactory);

--- a/src/Migration/Models/EntityOption.cs
+++ b/src/Migration/Models/EntityOption.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+
+namespace MongoDB.Extensions.Migration;
+
+public record EntityOption(
+    Type Type,
+    int CurrentVersion,
+    List<IMigration> Migrations);

--- a/src/Migration/Models/MigrationContext.cs
+++ b/src/Migration/Models/MigrationContext.cs
@@ -1,0 +1,5 @@
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.Extensions.Migration;
+
+public record MigrationContext(MigrationOption Option, ILoggerFactory LoggerFactory);

--- a/src/Migration/Models/MigrationOption.cs
+++ b/src/Migration/Models/MigrationOption.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace MongoDB.Extensions.Migration;
+
+public record MigrationOption(List<EntityOption> EntityOptions);

--- a/src/Migration/Readme.md
+++ b/src/Migration/Readme.md
@@ -10,10 +10,12 @@ With document databases which have a schema on read not on write we can do bette
 Introducing a version field on each document and having migration logic which performs the needed migrations when reading a document allows for a downtime free migrations.
 This pattern allows for multiple versions of an application to use the same database, for example in the case of a rolling update.
 
-## Api
+## Getting Started
 
-If used in combination with ASP.NET Core register your migrations with the `UseMongoMigration` extension method on the `IApplicationBuilder`.
-Either in Program.cs or in the Configure method of Startup.cs.
+1. Add MongoDB.Extensions.Migration to your project using `dotnet add package MongoDB.Extensions.Migration`
+2. Make sure that your your domain entities for which you want to write a migration implement the interface IVersioned
+3. Write a migration by creating a new class which implements IMigration, see below.
+4. Regsiter your migrations with the `UseMongoMigration` extension method on the `IApplicationBuilder`. Either in Program.cs or in the Configure method of Startup.cs.
 
 ```csharp
 ...
@@ -25,7 +27,13 @@ app.UseMongoMigration(m => m
         .WithMigration(new ExampleMigration())));
 
 
-public record Customer : IVersioned {...}
+public record Customer : IVersioned {
+  public int Version { get; set; }
+  public Guid Id {get; set;}
+  public string FirstName {get; set;}
+  public string LastName {get; set;}
+}
+
 public class ExampleMigration : IMigration {...}
 ```
 

--- a/src/Migration/Readme.md
+++ b/src/Migration/Readme.md
@@ -1,0 +1,60 @@
+# MongoDB.Extensions.Migration
+
+MongoDB.Extensions.Migration is a library which supports writing migrations for MongoDB in c#.
+Simple changes in the data model can often be accommodated by using data annotations from the MongoDB c# driver like `[BsonDefaultValue(...)]` but for more complicated changes the ability to write migrations is helpful.
+
+## Concept
+
+Traditionally in relational databases, migration have been applied to all documents at once and caused downtime.
+With document databases which have a schema on read not on write we can do better.
+Introducing a version field on each document and having migration logic which performs the needed migrations when reading a document allows for a downtime free migrations.
+This pattern allows for multiple versions of an application to use the same database, for example in the case of a rolling update.
+
+## Api
+
+If used in combination with ASP.NET Core register your migrations with the `UseMongoMigration` extension method on the `IApplicationBuilder`.
+Either in Program.cs or in the Configure method of Startup.cs.
+
+```csharp
+...
+var app = builder.Build();
+
+app.UseMongoMigration(m => m
+    .ForEntity<Customer>(e => e
+        .AtVersion(1)
+        .WithMigration(new ExampleMigration())));
+
+
+public record Customer : IVersioned {...}
+public class ExampleMigration : IMigration {...}
+```
+
+Entities for which a migration is needed must implement IVersioned and Migrations must implement IMigration.
+The optional method AtVersion allows setting the version of the data the application currently supports.
+This allows for scenarios where a migration down to a specific version is needed.
+
+### Writing Migrations
+
+Each migration has a version.
+The versions of all registered migrations must be continuously incrementing without a gap.
+We recommend to never change a already deployed migration.
+
+The up and down method of a migration act directly on the BsonDocument and allows making the needed changes to get from one version to another.
+This example shows how a typo in a field name is fixed.
+
+```csharp
+public class ExampleMigration : IMigration
+{
+    public int Version => 1;
+
+    public void Up(BsonDocument document)
+    {
+        document["Name"] = document["Namee"];
+    }
+
+    public void Down(BsonDocument document)
+    {
+        document["Namee"] = document["Name"];
+    }
+}
+```

--- a/src/MongoDB.Extensions.sln
+++ b/src/MongoDB.Extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29503.13
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Context", "Context\Context.csproj", "{57EA6D91-FB1A-4E68-82B7-A9AA58A400BE}"
 EndProject
@@ -20,6 +20,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transactions.Tests", "Transactions.Tests\Transactions.Tests.csproj", "{ADD0EC1E-226B-4122-B745-6D64435E064E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Context.InterferingTests", "Context.InterferingTests\Context.InterferingTests.csproj", "{6655AD69-6FD7-4AE2-BF09-53152911D7BE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Migration", "Migration\Migration.csproj", "{696254EA-91B9-4809-9D7F-EDD731C74622}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Migration.Tests", "Migration.Tests\Migration.Tests.csproj", "{A7D17D8A-99BC-40AC-92B4-996790F7F26E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +67,14 @@ Global
 		{6655AD69-6FD7-4AE2-BF09-53152911D7BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6655AD69-6FD7-4AE2-BF09-53152911D7BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6655AD69-6FD7-4AE2-BF09-53152911D7BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{696254EA-91B9-4809-9D7F-EDD731C74622}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{696254EA-91B9-4809-9D7F-EDD731C74622}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{696254EA-91B9-4809-9D7F-EDD731C74622}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{696254EA-91B9-4809-9D7F-EDD731C74622}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7D17D8A-99BC-40AC-92B4-996790F7F26E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7D17D8A-99BC-40AC-92B4-996790F7F26E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7D17D8A-99BC-40AC-92B4-996790F7F26E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7D17D8A-99BC-40AC-92B4-996790F7F26E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/TestProject.props
+++ b/src/TestProject.props
@@ -1,17 +1,17 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>$(TestProjectTargetFrameworks)</TargetFrameworks>    
+    <TargetFrameworks>$(TestProjectTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Snapshooter.Xunit" Version="0.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Squadron.Mongo" Version="0.13.0" />
+    <PackageReference Include="Squadron.Mongo" Version="0.15.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
MongoDB.Extensions.Migration allows to write migrations for MongoDB. 
Migrations are executed per document on read.
This allows for multi instance scenarios where different version of the application access the same database.

See [readme](https://github.com/SwissLife-OSS/mongo-extensions/blob/introduceMigration/src/Migration/Readme.md)