### PR TITLE
Added explicit setting of client session handle via parameter.

### DIFF
--- a/src/Transactions.Tests/TransactionCollectionTests.cs
+++ b/src/Transactions.Tests/TransactionCollectionTests.cs
@@ -8,447 +8,446 @@ using Xunit;
 using static System.Transactions.TransactionScopeAsyncFlowOption;
 using static System.Transactions.TransactionScopeOption;
 
-namespace MongoDB.Extensions.Transactions.Tests
-{
-    public class TransactionCollectionTests : IClassFixture<MongoReplicaSetResource>
-    {
-        private readonly MongoReplicaSetResource _mongoResource;
+namespace MongoDB.Extensions.Transactions.Tests;
 
-        public TransactionCollectionTests(MongoReplicaSetResource mongoResource)
+public class TransactionCollectionTests : IClassFixture<MongoReplicaSetResource>
+{
+    private readonly MongoReplicaSetResource _mongoResource;
+
+    public TransactionCollectionTests(MongoReplicaSetResource mongoResource)
+    {
+        _mongoResource = mongoResource;
+    }
+
+    [Fact]
+    public async Task Transaction_SuccessFull()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        var id = Guid.NewGuid();
+
+
+        // act
+        using (var scope = new TransactionScope(Enabled))
         {
-            _mongoResource = mongoResource;
+            User user = new(id, "Foo");
+            await collection.InsertOneAsync(user);
+
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task Transaction_SuccessFull()
+        // assert
+        Assert.Single(await collection.Find(x => x.Id == id).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Transaction_Fails_WithException()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        var id = Guid.NewGuid();
+
+        // act
+        try
         {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            var id = Guid.NewGuid();
-
-
-            // act
-            using (var scope = new TransactionScope(Enabled))
+            using (new TransactionScope(Enabled))
             {
                 User user = new(id, "Foo");
                 await collection.InsertOneAsync(user);
-
-                scope.Complete();
+                throw new InvalidOperationException();
             }
-
-            // assert
-            Assert.Single(await collection.Find(x => x.Id == id).ToListAsync());
+        }
+        catch
+        {
+            // ignored
         }
 
-        [Fact]
-        public async Task Transaction_Fails_WithException()
+        // assert
+        Assert.Empty(await collection.Find(x => x.Id == id).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Transaction_Fails_WithoutCommit()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        var id = Guid.NewGuid();
+
+        // act
+        try
         {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            var id = Guid.NewGuid();
-
-            // act
-            try
-            {
-                using (new TransactionScope(Enabled))
-                {
-                    User user = new(id, "Foo");
-                    await collection.InsertOneAsync(user);
-                    throw new InvalidOperationException();
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            // assert
-            Assert.Empty(await collection.Find(x => x.Id == id).ToListAsync());
-        }
-
-        [Fact]
-        public async Task Transaction_Fails_WithoutCommit()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            var id = Guid.NewGuid();
-
-            // act
-            try
-            {
-                using (new TransactionScope(Enabled))
-                {
-                    User user = new(id, "Foo");
-                    await collection.InsertOneAsync(user);
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            // assert
-            Assert.Empty(await collection.Find(x => x.Id == id).ToListAsync());
-        }
-
-        [Fact]
-        public async Task Transaction_Should_ReadChangesDuringTransaction()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            var id = Guid.NewGuid();
-            IReadOnlyList<User> users = Array.Empty<User>();
-
-            // act
             using (new TransactionScope(Enabled))
             {
-                User user = new User(id, "Foo3");
+                User user = new(id, "Foo");
                 await collection.InsertOneAsync(user);
-                users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
             }
-
-            // assert
-            Assert.Single(users);
-            Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+        }
+        catch
+        {
+            // ignored
         }
 
-        [Fact]
-        public async Task NestedTransaction_Should_Succeed()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
+        // assert
+        Assert.Empty(await collection.Find(x => x.Id == id).ToListAsync());
+    }
 
-            // act
-            using (var scope = new TransactionScope(Enabled))
+    [Fact]
+    public async Task Transaction_Should_ReadChangesDuringTransaction()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        var id = Guid.NewGuid();
+        IReadOnlyList<User> users = Array.Empty<User>();
+
+        // act
+        using (new TransactionScope(Enabled))
+        {
+            User user = new User(id, "Foo3");
+            await collection.InsertOneAsync(user);
+            users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        }
+
+        // assert
+        Assert.Single(users);
+        Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+    }
+
+    [Fact]
+    public async Task NestedTransaction_Should_Succeed()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope = new TransactionScope(Enabled))
+        {
+            User user1 = new(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
+
+            using (var innerScope =
+                new TransactionScope(Enabled))
             {
-                User user1 = new(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
-
-                using (var innerScope =
-                    new TransactionScope(Enabled))
-                {
-                    User user2 = new(Guid.NewGuid(), "Foo2");
-                    await collection.InsertOneAsync(user2);
-                    innerScope.Complete();
-                }
-
-                scope.Complete();
+                User user2 = new(Guid.NewGuid(), "Foo2");
+                await collection.InsertOneAsync(user2);
+                innerScope.Complete();
             }
 
-            // assert
-            List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
-            Assert.Equal(2, dbUsers.Count);
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task NestedTransaction_InnerTransactionNotCommitted()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
+        // assert
+        List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        Assert.Equal(2, dbUsers.Count);
+    }
 
-            // act
-            TransactionAbortedException ex = await Assert.ThrowsAsync<TransactionAbortedException>(
-                async () =>
+    [Fact]
+    public async Task NestedTransaction_InnerTransactionNotCommitted()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        TransactionAbortedException ex = await Assert.ThrowsAsync<TransactionAbortedException>(
+            async () =>
+            {
+                using (var scope = new TransactionScope(Enabled))
                 {
-                    using (var scope = new TransactionScope(Enabled))
-                    {
-                        User user1 = new(Guid.NewGuid(), "Foo1");
-                        await collection.InsertOneAsync(user1);
+                    User user1 = new(Guid.NewGuid(), "Foo1");
+                    await collection.InsertOneAsync(user1);
 
-                        using (var innerScope =
-                            new TransactionScope(Enabled))
+                    using (var innerScope =
+                        new TransactionScope(Enabled))
+                    {
+                        User user2 =
+                            new(Guid.NewGuid(), "Foo2");
+                        await collection.InsertOneAsync(user2);
+                    }
+
+                    scope.Complete();
+                }
+            });
+
+        // assert
+        Assert.Equal("The transaction has aborted.", ex.Message);
+        Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+    }
+
+    [Fact]
+    public async Task NestedTransaction_InnerThrowsException()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        TransactionAbortedException ex = await Assert.ThrowsAsync<TransactionAbortedException>(
+            async () =>
+            {
+                using (var scope = new TransactionScope(Enabled))
+                {
+                    User user1 = new(Guid.NewGuid(), "Foo1");
+                    await collection.InsertOneAsync(user1);
+
+                    try
+                    {
+                        using (var innerScope = new TransactionScope(Enabled))
                         {
                             User user2 =
                                 new(Guid.NewGuid(), "Foo2");
                             await collection.InsertOneAsync(user2);
+                            throw new Exception();
                         }
-
-                        scope.Complete();
                     }
-                });
-
-            // assert
-            Assert.Equal("The transaction has aborted.", ex.Message);
-            Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
-        }
-
-        [Fact]
-        public async Task NestedTransaction_InnerThrowsException()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-
-            // act
-            TransactionAbortedException ex = await Assert.ThrowsAsync<TransactionAbortedException>(
-                async () =>
-                {
-                    using (var scope = new TransactionScope(Enabled))
+                    catch
                     {
-                        User user1 = new(Guid.NewGuid(), "Foo1");
-                        await collection.InsertOneAsync(user1);
-
-                        try
-                        {
-                            using (var innerScope = new TransactionScope(Enabled))
-                            {
-                                User user2 =
-                                    new(Guid.NewGuid(), "Foo2");
-                                await collection.InsertOneAsync(user2);
-                                throw new Exception();
-                            }
-                        }
-                        catch
-                        {
-                        }
-
-                        scope.Complete();
                     }
-                });
 
-            // assert
-            Assert.Equal("The transaction has aborted.", ex.Message);
-            Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+                    scope.Complete();
+                }
+            });
+
+        // assert
+        Assert.Equal("The transaction has aborted.", ex.Message);
+        Assert.Empty(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+    }
+
+    [Fact]
+    public async Task NestedTransaction_RequiresNew_Should_Succeed()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        await collection
+            .InsertOneAsync(new User(Guid.NewGuid(), "Foo2"));
+
+        // act
+        using (var scope = new TransactionScope(RequiresNew, Enabled))
+        {
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
+
+            using (var innerScope = new TransactionScope(RequiresNew, Enabled))
+            {
+                var user2 = new User(Guid.NewGuid(), "Foo2");
+                await collection.InsertOneAsync(user2);
+                innerScope.Complete();
+            }
+
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task NestedTransaction_RequiresNew_Should_Succeed()
+        // assert
+        List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        Assert.Equal(3, dbUsers.Count);
+    }
+
+    [Fact]
+    public async Task NestedTransaction_RequiresNew_InnerTransactionNotCommitted()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope = new TransactionScope(RequiresNew, Enabled))
         {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            await collection
-                .InsertOneAsync(new User(Guid.NewGuid(), "Foo2"));
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
 
-            // act
-            using (var scope = new TransactionScope(RequiresNew, Enabled))
+            using (var innerScope = new TransactionScope(RequiresNew, Enabled))
             {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
+                var user2 = new User(Guid.NewGuid(), "Foo2");
+                await collection.InsertOneAsync(user2);
+            }
 
+            scope.Complete();
+        }
+
+        // assert
+        Assert.Single(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+    }
+
+    [Fact]
+    public async Task NestedTransaction_RequiresNew_InnerThrowsException()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope = new TransactionScope(RequiresNew, Enabled))
+        {
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
+
+            try
+            {
                 using (var innerScope = new TransactionScope(RequiresNew, Enabled))
                 {
                     var user2 = new User(Guid.NewGuid(), "Foo2");
                     await collection.InsertOneAsync(user2);
-                    innerScope.Complete();
+                    throw new Exception();
                 }
-
-                scope.Complete();
             }
-
-            // assert
-            List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
-            Assert.Equal(3, dbUsers.Count);
-        }
-
-        [Fact]
-        public async Task NestedTransaction_RequiresNew_InnerTransactionNotCommitted()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-
-            // act
-            using (var scope = new TransactionScope(RequiresNew, Enabled))
+            catch
             {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
-
-                using (var innerScope = new TransactionScope(RequiresNew, Enabled))
-                {
-                    var user2 = new User(Guid.NewGuid(), "Foo2");
-                    await collection.InsertOneAsync(user2);
-                }
-
-                scope.Complete();
             }
 
-            // assert
-            Assert.Single(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task NestedTransaction_RequiresNew_InnerThrowsException()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
+        // assert
+        Assert.Single(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+    }
 
-            // act
-            using (var scope = new TransactionScope(RequiresNew, Enabled))
+    [Fact]
+    public async Task NestedTransaction_Suppress_Should_Succeed()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope = new TransactionScope(TransactionScopeOption.Suppress, Enabled))
+        {
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
+
+            using (var innerScope = new TransactionScope(Enabled))
             {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
-
-                try
-                {
-                    using (var innerScope = new TransactionScope(RequiresNew, Enabled))
-                    {
-                        var user2 = new User(Guid.NewGuid(), "Foo2");
-                        await collection.InsertOneAsync(user2);
-                        throw new Exception();
-                    }
-                }
-                catch
-                {
-                }
-
-                scope.Complete();
+                var user2 = new User(Guid.NewGuid(), "Foo2");
+                await collection.InsertOneAsync(user2);
+                innerScope.Complete();
             }
 
-            // assert
-            Assert.Single(await collection.Find(FilterDefinition<User>.Empty).ToListAsync());
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task NestedTransaction_Suppress_Should_Succeed()
+        // assert
+        List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        Assert.Equal(2, dbUsers.Count);
+    }
+
+    [Fact]
+    public async Task NestedTransaction_Suppress_InnerTransactionNotCommitted()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope =
+            new TransactionScope(TransactionScopeOption.Suppress, Enabled))
         {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
 
-            // act
-            using (var scope = new TransactionScope(TransactionScopeOption.Suppress, Enabled))
-            {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
-
-                using (var innerScope = new TransactionScope(Enabled))
-                {
-                    var user2 = new User(Guid.NewGuid(), "Foo2");
-                    await collection.InsertOneAsync(user2);
-                    innerScope.Complete();
-                }
-
-                scope.Complete();
-            }
-
-            // assert
-            List<User> dbUsers = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
-            Assert.Equal(2, dbUsers.Count);
-        }
-
-        [Fact]
-        public async Task NestedTransaction_Suppress_InnerTransactionNotCommitted()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-
-            // act
-            using (var scope =
+            using (var innerScope =
                 new TransactionScope(TransactionScopeOption.Suppress, Enabled))
             {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
+                var user2 = new User(Guid.NewGuid(), "Foo2");
+                await collection.InsertOneAsync(user2);
+            }
 
+            scope.Complete();
+        }
+
+        // assert
+        List<User> users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        Assert.Equal(2, users.Count);
+    }
+
+    [Fact]
+    public async Task NestedTransaction_Suppress_InnerThrowsException()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+
+        // act
+        using (var scope =
+            new TransactionScope(TransactionScopeOption.Suppress, Enabled))
+        {
+            var user1 = new User(Guid.NewGuid(), "Foo1");
+            await collection.InsertOneAsync(user1);
+
+            try
+            {
                 using (var innerScope =
                     new TransactionScope(TransactionScopeOption.Suppress, Enabled))
                 {
                     var user2 = new User(Guid.NewGuid(), "Foo2");
                     await collection.InsertOneAsync(user2);
+                    throw new Exception();
                 }
-
-                scope.Complete();
+            }
+            catch
+            {
             }
 
-            // assert
-            List<User> users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
-            Assert.Equal(2, users.Count);
+            scope.Complete();
         }
 
-        [Fact]
-        public async Task NestedTransaction_Suppress_InnerThrowsException()
+        // assert
+        List<User> users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
+        Assert.Equal(2, users.Count);
+    }
+
+    [Fact]
+    public async Task Transaction_SuccessFull_Concurrent()
+    {
+        // arrange
+        IMongoDatabase database = _mongoResource.CreateDatabase();
+        IMongoCollection<User> collection =
+            database.GetCollection<User>("users").AsTransactionCollection();
+        var tasks = new List<Task>();
+        const int taskCount = 10;
+        const int documentCount = 10;
+        await collection.InsertOneAsync(
+            new User(Guid.NewGuid(), "Foo"));
+
+        // act
+        for (var i = 0; i < taskCount; i++)
         {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-
-            // act
-            using (var scope =
-                new TransactionScope(TransactionScopeOption.Suppress, Enabled))
+            async Task task()
             {
-                var user1 = new User(Guid.NewGuid(), "Foo1");
-                await collection.InsertOneAsync(user1);
-
-                try
+                for (var j = 0; j < documentCount; j++)
                 {
-                    using (var innerScope =
-                        new TransactionScope(TransactionScopeOption.Suppress, Enabled))
+                    using (var scope = new TransactionScope(Enabled))
                     {
-                        var user2 = new User(Guid.NewGuid(), "Foo2");
-                        await collection.InsertOneAsync(user2);
-                        throw new Exception();
+                        await collection.InsertOneAsync(
+                            new User(Guid.NewGuid(), "Foo"));
+
+                        scope.Complete();
                     }
                 }
-                catch
-                {
-                }
-
-                scope.Complete();
             }
 
-            // assert
-            List<User> users = await collection.Find(FilterDefinition<User>.Empty).ToListAsync();
-            Assert.Equal(2, users.Count);
+            tasks.Add(task());
         }
 
-        [Fact]
-        public async Task Transaction_SuccessFull_Concurrent()
-        {
-            // arrange
-            IMongoDatabase database = _mongoResource.CreateDatabase();
-            IMongoCollection<User> collection =
-                database.GetCollection<User>("users").AsTransactionCollection();
-            var tasks = new List<Task>();
-            const int taskCount = 10;
-            const int documentCount = 10;
-            await collection.InsertOneAsync(
-                new User(Guid.NewGuid(), "Foo"));
+        await Task.WhenAll(tasks);
 
-            // act
-            for (var i = 0; i < taskCount; i++)
-            {
-                async Task task()
-                {
-                    for (var j = 0; j < documentCount; j++)
-                    {
-                        using (var scope = new TransactionScope(Enabled))
-                        {
-                            await collection.InsertOneAsync(
-                                new User(Guid.NewGuid(), "Foo"));
-
-                            scope.Complete();
-                        }
-                    }
-                }
-
-                tasks.Add(task());
-            }
-
-            await Task.WhenAll(tasks);
-
-            // assert
-            Assert.Equal(101, await collection.CountDocumentsAsync(FilterDefinition<User>.Empty));
-        }
+        // assert
+        Assert.Equal(101, await collection.CountDocumentsAsync(FilterDefinition<User>.Empty));
     }
 }

--- a/src/Transactions/MongoTransactionClient.cs
+++ b/src/Transactions/MongoTransactionClient.cs
@@ -1,292 +1,307 @@
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public class MongoTransactionClient : IMongoClient
 {
-    public class MongoTransactionClient : IMongoClient
+    private readonly IMongoClient _client;
+    private readonly IClientSessionHandle? _clientSessionHandle;
+
+    public MongoTransactionClient(IMongoClient client)
     {
-        private readonly IMongoClient _client;
+        _client = client;
+    }
 
-        public MongoTransactionClient(IMongoClient client)
-        {
-            _client = client;
-        }
+    public MongoTransactionClient(
+        IMongoClient client,
+        IClientSessionHandle clientSessionHandle)
+    {
+        _client = client;
+        _clientSessionHandle = clientSessionHandle;
+    }
 
-        public void DropDatabase(
-            string name,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _client.DropDatabase(session, name, cancellationToken);
-                return;
-            }
-
-            _client.DropDatabase(name, cancellationToken);
-        }
-
-        public void DropDatabase(
-            IClientSessionHandle session,
-            string name,
-            CancellationToken cancellationToken = default)
+    public void DropDatabase(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             _client.DropDatabase(session, name, cancellationToken);
+            return;
         }
 
-        public Task DropDatabaseAsync(
-            string name,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.DropDatabaseAsync(session, name, cancellationToken);
-            }
+        _client.DropDatabase(name, cancellationToken);
+    }
 
-            return _client.DropDatabaseAsync(name, cancellationToken);
-        }
+    public void DropDatabase(
+        IClientSessionHandle session,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        _client.DropDatabase(session, name, cancellationToken);
+    }
 
-        public Task DropDatabaseAsync(
-            IClientSessionHandle session,
-            string name,
-            CancellationToken cancellationToken = default)
+    public Task DropDatabaseAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.DropDatabaseAsync(session, name, cancellationToken);
         }
 
-        public IMongoDatabase GetDatabase(string name, MongoDatabaseSettings? settings = null)
-        {
-            return _client.GetDatabase(name, settings).AsTransactionDatabase();
-        }
+        return _client.DropDatabaseAsync(name, cancellationToken);
+    }
 
-        public IAsyncCursor<string> ListDatabaseNames(CancellationToken cancellationToken = default)
-        {
-            return _client.ListDatabaseNames(cancellationToken);
-        }
+    public Task DropDatabaseAsync(
+        IClientSessionHandle session,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.DropDatabaseAsync(session, name, cancellationToken);
+    }
 
-        public IAsyncCursor<string> ListDatabaseNames(
-            ListDatabaseNamesOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabaseNames(session, options, cancellationToken);
-            }
+    public IMongoDatabase GetDatabase(string name, MongoDatabaseSettings? settings = null)
+    {
+        return _client.GetDatabase(name, settings).AsTransactionDatabase();
+    }
 
-            return _client.ListDatabaseNames(options, cancellationToken);
-        }
+    public IAsyncCursor<string> ListDatabaseNames(CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabaseNames(cancellationToken);
+    }
 
-        public IAsyncCursor<string> ListDatabaseNames(
-            IClientSessionHandle session,
-            CancellationToken cancellationToken = default)
-        {
-            return _client.ListDatabaseNames(session, cancellationToken);
-        }
-
-        public IAsyncCursor<string> ListDatabaseNames(
-            IClientSessionHandle session,
-            ListDatabaseNamesOptions options,
-            CancellationToken cancellationToken = default)
+    public IAsyncCursor<string> ListDatabaseNames(
+        ListDatabaseNamesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabaseNames(session, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabaseNamesAsync(session, cancellationToken);
-            }
+        return _client.ListDatabaseNames(options, cancellationToken);
+    }
 
-            return _client.ListDatabaseNamesAsync(cancellationToken);
-        }
+    public IAsyncCursor<string> ListDatabaseNames(
+        IClientSessionHandle session,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabaseNames(session, cancellationToken);
+    }
 
-        public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
-            ListDatabaseNamesOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabaseNamesAsync(session, cancellationToken);
-            }
+    public IAsyncCursor<string> ListDatabaseNames(
+        IClientSessionHandle session,
+        ListDatabaseNamesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabaseNames(session, options, cancellationToken);
+    }
 
-            return _client.ListDatabaseNamesAsync(options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
-            IClientSessionHandle session,
-            CancellationToken cancellationToken = default)
+    public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabaseNamesAsync(session, cancellationToken);
         }
 
-        public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
-            IClientSessionHandle session,
-            ListDatabaseNamesOptions options,
-            CancellationToken cancellationToken = default)
+        return _client.ListDatabaseNamesAsync(cancellationToken);
+    }
+
+    public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
+        ListDatabaseNamesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _client.ListDatabaseNamesAsync(session, options, cancellationToken);
+            return _client.ListDatabaseNamesAsync(session, cancellationToken);
         }
 
-        public IAsyncCursor<BsonDocument> ListDatabases(
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabases(session, cancellationToken);
-            }
+        return _client.ListDatabaseNamesAsync(options, cancellationToken);
+    }
 
-            return _client.ListDatabases(cancellationToken);
-        }
+    public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
+        IClientSessionHandle session,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabaseNamesAsync(session, cancellationToken);
+    }
 
-        public IAsyncCursor<BsonDocument> ListDatabases(
-            ListDatabasesOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabases(session, options, cancellationToken);
-            }
+    public Task<IAsyncCursor<string>> ListDatabaseNamesAsync(
+        IClientSessionHandle session,
+        ListDatabaseNamesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabaseNamesAsync(session, options, cancellationToken);
+    }
 
-            return _client.ListDatabases(options, cancellationToken);
-        }
-
-        public IAsyncCursor<BsonDocument> ListDatabases(
-            IClientSessionHandle session,
-            CancellationToken cancellationToken = default)
+    public IAsyncCursor<BsonDocument> ListDatabases(
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabases(session, cancellationToken);
         }
 
-        public IAsyncCursor<BsonDocument> ListDatabases(
-            IClientSessionHandle session,
-            ListDatabasesOptions options,
-            CancellationToken cancellationToken = default)
+        return _client.ListDatabases(cancellationToken);
+    }
+
+    public IAsyncCursor<BsonDocument> ListDatabases(
+        ListDatabasesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabases(session, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabasesAsync(session, cancellationToken);
-            }
+        return _client.ListDatabases(options, cancellationToken);
+    }
 
-            return _client.ListDatabasesAsync(cancellationToken);
-        }
+    public IAsyncCursor<BsonDocument> ListDatabases(
+        IClientSessionHandle session,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabases(session, cancellationToken);
+    }
 
-        public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
-            ListDatabasesOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.ListDatabasesAsync(session, options, cancellationToken);
-            }
+    public IAsyncCursor<BsonDocument> ListDatabases(
+        IClientSessionHandle session,
+        ListDatabasesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabases(session, options, cancellationToken);
+    }
 
-            return _client.ListDatabasesAsync(options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
-            IClientSessionHandle session,
-            CancellationToken cancellationToken = default)
+    public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabasesAsync(session, cancellationToken);
         }
 
-        public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
-            IClientSessionHandle session,
-            ListDatabasesOptions options,
-            CancellationToken cancellationToken = default)
+        return _client.ListDatabasesAsync(cancellationToken);
+    }
+
+    public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
+        ListDatabasesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.ListDatabasesAsync(session, options, cancellationToken);
         }
 
-        public IClientSessionHandle StartSession(
-            ClientSessionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _client.StartSession(options, cancellationToken);
-        }
+        return _client.ListDatabasesAsync(options, cancellationToken);
+    }
 
-        public Task<IClientSessionHandle> StartSessionAsync(
-            ClientSessionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _client.StartSessionAsync(options, cancellationToken);
-        }
+    public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
+        IClientSessionHandle session,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabasesAsync(session, cancellationToken);
+    }
 
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.Watch(session, pipeline, options, cancellationToken);
-            }
+    public Task<IAsyncCursor<BsonDocument>> ListDatabasesAsync(
+        IClientSessionHandle session,
+        ListDatabasesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.ListDatabasesAsync(session, options, cancellationToken);
+    }
 
-            return _client.Watch(pipeline, options, cancellationToken);
-        }
+    public IClientSessionHandle StartSession(
+        ClientSessionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.StartSession(options, cancellationToken);
+    }
 
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IClientSessionHandle> StartSessionAsync(
+        ClientSessionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.StartSessionAsync(options, cancellationToken);
+    }
+
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.Watch(session, pipeline, options, cancellationToken);
         }
 
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _client.WatchAsync(session, pipeline, options, cancellationToken);
-            }
+        return _client.Watch(pipeline, options, cancellationToken);
+    }
 
-            return _client.WatchAsync(pipeline, options, cancellationToken);
-        }
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.Watch(session, pipeline, options, cancellationToken);
+    }
 
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _client.WatchAsync(session, pipeline, options, cancellationToken);
         }
 
-        public IMongoClient WithReadConcern(ReadConcern readConcern)
-        {
-            return _client.WithReadConcern(readConcern).AsTransactionClient();
-        }
-
-        public IMongoClient WithReadPreference(ReadPreference readPreference)
-        {
-            return _client.WithReadPreference(readPreference).AsTransactionClient();
-        }
-
-        public IMongoClient WithWriteConcern(WriteConcern writeConcern)
-        {
-            return _client.WithWriteConcern(writeConcern).AsTransactionClient();
-        }
-
-        public ICluster Cluster => _client.Cluster;
-
-        public MongoClientSettings Settings => _client.Settings;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryGetSession(out IClientSessionHandle sessionHandle) =>
-            TransactionStore.TryGetSession(_client, out sessionHandle);
+        return _client.WatchAsync(pipeline, options, cancellationToken);
     }
+
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _client.WatchAsync(session, pipeline, options, cancellationToken);
+    }
+
+    public IMongoClient WithReadConcern(ReadConcern readConcern)
+    {
+        return _client.WithReadConcern(readConcern).AsTransactionClient();
+    }
+
+    public IMongoClient WithReadPreference(ReadPreference readPreference)
+    {
+        return _client.WithReadPreference(readPreference).AsTransactionClient();
+    }
+
+    public IMongoClient WithWriteConcern(WriteConcern writeConcern)
+    {
+        return _client.WithWriteConcern(writeConcern).AsTransactionClient();
+    }
+
+    public ICluster Cluster => _client.Cluster;
+
+    public MongoClientSettings Settings => _client.Settings;
+
+    private bool TryGetSession(out IClientSessionHandle sessionHandle)
+    {
+        if (_clientSessionHandle is { } clientSessionHandle)
+        {
+            sessionHandle = clientSessionHandle;
+            return true;
+        }
+
+        return TransactionStore.TryGetSession(
+            _client, out sessionHandle);
+    }            
 }

--- a/src/Transactions/MongoTransactionCollection.cs
+++ b/src/Transactions/MongoTransactionCollection.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -8,1073 +7,1091 @@ using MongoDB.Driver;
 
 #pragma warning disable 618
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public class MongoTransactionCollection<T> : IMongoCollection<T>
 {
-    public class MongoTransactionCollection<T> : IMongoCollection<T>
+    private readonly IMongoCollection<T> _collection;
+    private readonly IClientSessionHandle? _clientSessionHandle;
+
+    public MongoTransactionCollection(
+        IMongoCollection<T> collection)
     {
-        private readonly IMongoCollection<T> _collection;
+        _collection = collection;
+    }
 
-        public MongoTransactionCollection(IMongoCollection<T> collection)
+    public MongoTransactionCollection(
+        IMongoCollection<T> collection,
+        IClientSessionHandle clientSessionHandle)
+    {
+        _collection = collection;
+        _clientSessionHandle = clientSessionHandle;
+    }
+
+    public IAsyncCursor<TResult> Aggregate<TResult>(
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            _collection = collection;
+            return Aggregate(session, pipeline, options, cancellationToken);
         }
 
-        public IAsyncCursor<TResult> Aggregate<TResult>(
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return Aggregate(session, pipeline, options, cancellationToken);
-            }
+        return _collection.Aggregate(pipeline, options, cancellationToken);
+    }
 
-            return _collection.Aggregate(pipeline, options, cancellationToken);
+    public IAsyncCursor<TResult> Aggregate<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.Aggregate(session, pipeline, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return AggregateAsync(session, pipeline, options, cancellationToken);
         }
 
-        public IAsyncCursor<TResult> Aggregate<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.AggregateAsync(pipeline, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.AggregateAsync(session, pipeline, options, cancellationToken);
+    }
+
+    public void AggregateToCollection<TResult>(
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.Aggregate(session, pipeline, options, cancellationToken);
+            AggregateToCollection(session, pipeline, options, cancellationToken);
+            return;
         }
 
-        public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return AggregateAsync(session, pipeline, options, cancellationToken);
-            }
+        _collection.AggregateToCollection(pipeline, options, cancellationToken);
+    }
 
-            return _collection.AggregateAsync(pipeline, options, cancellationToken);
+    public void AggregateToCollection<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _collection.AggregateToCollection(session, pipeline, options, cancellationToken);
+    }
+
+    public Task AggregateToCollectionAsync<TResult>(
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return AggregateToCollectionAsync(session, pipeline, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.AggregateToCollectionAsync(pipeline, options, cancellationToken);
+    }
+
+    public Task AggregateToCollectionAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<T, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.AggregateToCollectionAsync(session,
+            pipeline,
+            options,
+            cancellationToken);
+    }
+
+    public BulkWriteResult<T> BulkWrite(
+        IEnumerable<WriteModel<T>> requests,
+        BulkWriteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.AggregateAsync(session, pipeline, options, cancellationToken);
+            return BulkWrite(session, requests, options, cancellationToken);
         }
 
-        public void AggregateToCollection<TResult>(
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                AggregateToCollection(session, pipeline, options, cancellationToken);
-                return;
-            }
+        return _collection.BulkWrite(requests, options, cancellationToken);
+    }
 
-            _collection.AggregateToCollection(pipeline, options, cancellationToken);
+    public BulkWriteResult<T> BulkWrite(
+        IClientSessionHandle session,
+        IEnumerable<WriteModel<T>> requests,
+        BulkWriteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.BulkWrite(session, requests, options, cancellationToken);
+    }
+
+    public Task<BulkWriteResult<T>> BulkWriteAsync(
+        IEnumerable<WriteModel<T>> requests,
+        BulkWriteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return BulkWriteAsync(session, requests, options, cancellationToken);
         }
 
-        public void AggregateToCollection<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.BulkWriteAsync(requests, options, cancellationToken);
+    }
+
+    public Task<BulkWriteResult<T>> BulkWriteAsync(
+        IClientSessionHandle session,
+        IEnumerable<WriteModel<T>> requests,
+        BulkWriteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.BulkWriteAsync(session, requests, options, cancellationToken);
+    }
+
+    public long Count(
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            _collection.AggregateToCollection(session, pipeline, options, cancellationToken);
+            return Count(session, filter, options, cancellationToken);
         }
 
-        public Task AggregateToCollectionAsync<TResult>(
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return AggregateToCollectionAsync(session, pipeline, options, cancellationToken);
-            }
+        return _collection.Count(filter, options, cancellationToken);
+    }
 
-            return _collection.AggregateToCollectionAsync(pipeline, options, cancellationToken);
+    public long Count(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.Count(session, filter, options, cancellationToken);
+    }
+
+    public Task<long> CountAsync(
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return CountAsync(session, filter, options, cancellationToken);
         }
 
-        public Task AggregateToCollectionAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<T, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.CountAsync(filter, options, cancellationToken);
+    }
+
+    public Task<long> CountAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.CountAsync(session, filter, options, cancellationToken);
+    }
+
+    public long CountDocuments(
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.AggregateToCollectionAsync(session,
-                pipeline,
-                options,
-                cancellationToken);
+            return CountDocuments(session, filter, options, cancellationToken);
         }
 
-        public BulkWriteResult<T> BulkWrite(
-            IEnumerable<WriteModel<T>> requests,
-            BulkWriteOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return BulkWrite(session, requests, options, cancellationToken);
-            }
+        return _collection.CountDocuments(filter, options, cancellationToken);
+    }
 
-            return _collection.BulkWrite(requests, options, cancellationToken);
+    public long CountDocuments(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.CountDocuments(session, filter, options, cancellationToken);
+    }
+
+    public Task<long> CountDocumentsAsync(
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return CountDocumentsAsync(session, filter, options, cancellationToken);
         }
 
-        public BulkWriteResult<T> BulkWrite(
-            IClientSessionHandle session,
-            IEnumerable<WriteModel<T>> requests,
-            BulkWriteOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.CountDocumentsAsync(filter, options, cancellationToken);
+    }
+
+    public Task<long> CountDocumentsAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.CountDocumentsAsync(session, filter, options, cancellationToken);
+    }
+
+    public DeleteResult DeleteMany(
+        FilterDefinition<T> filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.BulkWrite(session, requests, options, cancellationToken);
+            return DeleteMany(session, filter, cancellationToken: cancellationToken);
         }
 
-        public Task<BulkWriteResult<T>> BulkWriteAsync(
-            IEnumerable<WriteModel<T>> requests,
-            BulkWriteOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return BulkWriteAsync(session, requests, options, cancellationToken);
-            }
+        return _collection.DeleteMany(filter, cancellationToken);
+    }
 
-            return _collection.BulkWriteAsync(requests, options, cancellationToken);
+    public DeleteResult DeleteMany(
+        FilterDefinition<T> filter,
+        DeleteOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return DeleteMany(session, filter, options, cancellationToken);
         }
 
-        public Task<BulkWriteResult<T>> BulkWriteAsync(
-            IClientSessionHandle session,
-            IEnumerable<WriteModel<T>> requests,
-            BulkWriteOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.DeleteMany(filter, options, cancellationToken);
+    }
+
+    public DeleteResult DeleteMany(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        DeleteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.DeleteMany(session, filter, options, cancellationToken);
+    }
+
+    public Task<DeleteResult> DeleteManyAsync(
+        FilterDefinition<T> filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.BulkWriteAsync(session, requests, options, cancellationToken);
+            return DeleteManyAsync(session, filter, cancellationToken: cancellationToken);
         }
 
-        public long Count(
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return Count(session, filter, options, cancellationToken);
-            }
+        return _collection.DeleteManyAsync(filter, cancellationToken);
+    }
 
-            return _collection.Count(filter, options, cancellationToken);
+    public Task<DeleteResult> DeleteManyAsync(
+        FilterDefinition<T> filter,
+        DeleteOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return DeleteManyAsync(session, filter, options, cancellationToken);
         }
 
-        public long Count(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.DeleteManyAsync(filter, options, cancellationToken);
+    }
+
+    public Task<DeleteResult> DeleteManyAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        DeleteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.DeleteManyAsync(session, filter, options, cancellationToken);
+    }
+
+    public DeleteResult DeleteOne(
+        FilterDefinition<T> filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.Count(session, filter, options, cancellationToken);
+            return DeleteOne(session, filter, cancellationToken: cancellationToken);
         }
 
-        public Task<long> CountAsync(
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return CountAsync(session, filter, options, cancellationToken);
-            }
+        return _collection.DeleteOne(filter, cancellationToken);
+    }
 
-            return _collection.CountAsync(filter, options, cancellationToken);
+    public DeleteResult DeleteOne(
+        FilterDefinition<T> filter,
+        DeleteOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return DeleteOne(session, filter, options, cancellationToken);
         }
 
-        public Task<long> CountAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.DeleteOne(filter, options, cancellationToken);
+    }
+
+    public DeleteResult DeleteOne(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        DeleteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.DeleteOne(session, filter, options, cancellationToken);
+    }
+
+    public Task<DeleteResult> DeleteOneAsync(
+        FilterDefinition<T> filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.CountAsync(session, filter, options, cancellationToken);
+            return DeleteOneAsync(session, filter, cancellationToken: cancellationToken);
         }
 
-        public long CountDocuments(
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return CountDocuments(session, filter, options, cancellationToken);
-            }
+        return _collection.DeleteOneAsync(filter, cancellationToken);
+    }
 
-            return _collection.CountDocuments(filter, options, cancellationToken);
+    public Task<DeleteResult> DeleteOneAsync(
+        FilterDefinition<T> filter,
+        DeleteOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return DeleteOneAsync(session, filter, options, cancellationToken);
         }
 
-        public long CountDocuments(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.DeleteOneAsync(filter, options, cancellationToken);
+    }
+
+    public Task<DeleteResult> DeleteOneAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        DeleteOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.DeleteOneAsync(session, filter, options, cancellationToken);
+    }
+
+    public IAsyncCursor<TField> Distinct<TField>(
+        FieldDefinition<T, TField> field,
+        FilterDefinition<T> filter,
+        DistinctOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.CountDocuments(session, filter, options, cancellationToken);
+            return Distinct(session, field, filter, options, cancellationToken);
         }
 
-        public Task<long> CountDocumentsAsync(
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return CountDocumentsAsync(session, filter, options, cancellationToken);
-            }
+        return _collection.Distinct(field, filter, options, cancellationToken);
+    }
 
-            return _collection.CountDocumentsAsync(filter, options, cancellationToken);
+    public IAsyncCursor<TField> Distinct<TField>(
+        IClientSessionHandle session,
+        FieldDefinition<T, TField> field,
+        FilterDefinition<T> filter,
+        DistinctOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.Distinct(session, field, filter, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TField>> DistinctAsync<TField>(
+        FieldDefinition<T, TField> field,
+        FilterDefinition<T> filter,
+        DistinctOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return DistinctAsync(session, field, filter, options, cancellationToken);
         }
 
-        public Task<long> CountDocumentsAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            CountOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.DistinctAsync(field, filter, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TField>> DistinctAsync<TField>(
+        IClientSessionHandle session,
+        FieldDefinition<T, TField> field,
+        FilterDefinition<T> filter,
+        DistinctOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.DistinctAsync(session, field, filter, options, cancellationToken);
+    }
+
+    public long EstimatedDocumentCount(
+        EstimatedDocumentCountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.EstimatedDocumentCount(options, cancellationToken);
+    }
+
+    public Task<long> EstimatedDocumentCountAsync(
+        EstimatedDocumentCountOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.EstimatedDocumentCountAsync(options, cancellationToken);
+    }
+
+    public IAsyncCursor<TProjection> FindSync<TProjection>(
+        FilterDefinition<T> filter,
+        FindOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.CountDocumentsAsync(session, filter, options, cancellationToken);
+            return FindSync(session, filter, options, cancellationToken);
         }
 
-        public DeleteResult DeleteMany(
-            FilterDefinition<T> filter,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteMany(session, filter, cancellationToken: cancellationToken);
-            }
+        return _collection.FindSync(filter, options, cancellationToken);
+    }
 
-            return _collection.DeleteMany(filter, cancellationToken);
+    public IAsyncCursor<TProjection> FindSync<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        FindOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindSync(session, filter, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TProjection>> FindAsync<TProjection>(
+        FilterDefinition<T> filter,
+        FindOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return FindAsync(session, filter, options, cancellationToken);
         }
 
-        public DeleteResult DeleteMany(
-            FilterDefinition<T> filter,
-            DeleteOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteMany(session, filter, options, cancellationToken);
-            }
+        return _collection.FindAsync(filter, options, cancellationToken);
+    }
 
-            return _collection.DeleteMany(filter, options, cancellationToken);
+    public Task<IAsyncCursor<TProjection>> FindAsync<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        FindOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindAsync(session, filter, options, cancellationToken);
+    }
+
+    public TProjection FindOneAndDelete<TProjection>(
+        FilterDefinition<T> filter,
+        FindOneAndDeleteOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return FindOneAndDelete(session, filter, options, cancellationToken);
         }
 
-        public DeleteResult DeleteMany(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            DeleteOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.FindOneAndDelete(filter, options, cancellationToken);
+    }
+
+    public TProjection FindOneAndDelete<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        FindOneAndDeleteOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndDelete(session, filter, options, cancellationToken);
+    }
+
+    public Task<TProjection> FindOneAndDeleteAsync<TProjection>(
+        FilterDefinition<T> filter,
+        FindOneAndDeleteOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.DeleteMany(session, filter, options, cancellationToken);
+            return FindOneAndDeleteAsync(session, filter, options, cancellationToken);
         }
 
-        public Task<DeleteResult> DeleteManyAsync(
-            FilterDefinition<T> filter,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteManyAsync(session, filter, cancellationToken: cancellationToken);
-            }
+        return _collection.FindOneAndDeleteAsync(filter, options, cancellationToken);
+    }
 
-            return _collection.DeleteManyAsync(filter, cancellationToken);
+    public Task<TProjection> FindOneAndDeleteAsync<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        FindOneAndDeleteOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndDeleteAsync(session, filter, options, cancellationToken);
+    }
+
+    public TProjection FindOneAndReplace<TProjection>(
+        FilterDefinition<T> filter,
+        T replacement,
+        FindOneAndReplaceOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return FindOneAndReplace(session, filter, replacement, options, cancellationToken);
         }
 
-        public Task<DeleteResult> DeleteManyAsync(
-            FilterDefinition<T> filter,
-            DeleteOptions options,
-            CancellationToken cancellationToken = default)
+        return _collection.FindOneAndReplace(filter, replacement, options, cancellationToken);
+    }
+
+    public TProjection FindOneAndReplace<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        FindOneAndReplaceOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndReplace(session,
+            filter,
+            replacement,
+            options,
+            cancellationToken);
+    }
+
+    public Task<TProjection> FindOneAndReplaceAsync<TProjection>(
+        FilterDefinition<T> filter,
+        T replacement,
+        FindOneAndReplaceOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteManyAsync(session, filter, options, cancellationToken);
-            }
-
-            return _collection.DeleteManyAsync(filter, options, cancellationToken);
-        }
-
-        public Task<DeleteResult> DeleteManyAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            DeleteOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.DeleteManyAsync(session, filter, options, cancellationToken);
-        }
-
-        public DeleteResult DeleteOne(
-            FilterDefinition<T> filter,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteOne(session, filter, cancellationToken: cancellationToken);
-            }
-
-            return _collection.DeleteOne(filter, cancellationToken);
-        }
-
-        public DeleteResult DeleteOne(
-            FilterDefinition<T> filter,
-            DeleteOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteOne(session, filter, options, cancellationToken);
-            }
-
-            return _collection.DeleteOne(filter, options, cancellationToken);
-        }
-
-        public DeleteResult DeleteOne(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            DeleteOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.DeleteOne(session, filter, options, cancellationToken);
-        }
-
-        public Task<DeleteResult> DeleteOneAsync(
-            FilterDefinition<T> filter,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteOneAsync(session, filter, cancellationToken: cancellationToken);
-            }
-
-            return _collection.DeleteOneAsync(filter, cancellationToken);
-        }
-
-        public Task<DeleteResult> DeleteOneAsync(
-            FilterDefinition<T> filter,
-            DeleteOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DeleteOneAsync(session, filter, options, cancellationToken);
-            }
-
-            return _collection.DeleteOneAsync(filter, options, cancellationToken);
-        }
-
-        public Task<DeleteResult> DeleteOneAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            DeleteOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.DeleteOneAsync(session, filter, options, cancellationToken);
-        }
-
-        public IAsyncCursor<TField> Distinct<TField>(
-            FieldDefinition<T, TField> field,
-            FilterDefinition<T> filter,
-            DistinctOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return Distinct(session, field, filter, options, cancellationToken);
-            }
-
-            return _collection.Distinct(field, filter, options, cancellationToken);
-        }
-
-        public IAsyncCursor<TField> Distinct<TField>(
-            IClientSessionHandle session,
-            FieldDefinition<T, TField> field,
-            FilterDefinition<T> filter,
-            DistinctOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.Distinct(session, field, filter, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TField>> DistinctAsync<TField>(
-            FieldDefinition<T, TField> field,
-            FilterDefinition<T> filter,
-            DistinctOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return DistinctAsync(session, field, filter, options, cancellationToken);
-            }
-
-            return _collection.DistinctAsync(field, filter, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TField>> DistinctAsync<TField>(
-            IClientSessionHandle session,
-            FieldDefinition<T, TField> field,
-            FilterDefinition<T> filter,
-            DistinctOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.DistinctAsync(session, field, filter, options, cancellationToken);
-        }
-
-        public long EstimatedDocumentCount(
-            EstimatedDocumentCountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.EstimatedDocumentCount(options, cancellationToken);
-        }
-
-        public Task<long> EstimatedDocumentCountAsync(
-            EstimatedDocumentCountOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.EstimatedDocumentCountAsync(options, cancellationToken);
-        }
-
-        public IAsyncCursor<TProjection> FindSync<TProjection>(
-            FilterDefinition<T> filter,
-            FindOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindSync(session, filter, options, cancellationToken);
-            }
-
-            return _collection.FindSync(filter, options, cancellationToken);
-        }
-
-        public IAsyncCursor<TProjection> FindSync<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            FindOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.FindSync(session, filter, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TProjection>> FindAsync<TProjection>(
-            FilterDefinition<T> filter,
-            FindOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindAsync(session, filter, options, cancellationToken);
-            }
-
-            return _collection.FindAsync(filter, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TProjection>> FindAsync<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            FindOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.FindAsync(session, filter, options, cancellationToken);
-        }
-
-        public TProjection FindOneAndDelete<TProjection>(
-            FilterDefinition<T> filter,
-            FindOneAndDeleteOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndDelete(session, filter, options, cancellationToken);
-            }
-
-            return _collection.FindOneAndDelete(filter, options, cancellationToken);
-        }
-
-        public TProjection FindOneAndDelete<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            FindOneAndDeleteOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.FindOneAndDelete(session, filter, options, cancellationToken);
-        }
-
-        public Task<TProjection> FindOneAndDeleteAsync<TProjection>(
-            FilterDefinition<T> filter,
-            FindOneAndDeleteOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndDeleteAsync(session, filter, options, cancellationToken);
-            }
-
-            return _collection.FindOneAndDeleteAsync(filter, options, cancellationToken);
-        }
-
-        public Task<TProjection> FindOneAndDeleteAsync<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            FindOneAndDeleteOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.FindOneAndDeleteAsync(session, filter, options, cancellationToken);
-        }
-
-        public TProjection FindOneAndReplace<TProjection>(
-            FilterDefinition<T> filter,
-            T replacement,
-            FindOneAndReplaceOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndReplace(session, filter, replacement, options, cancellationToken);
-            }
-
-            return _collection.FindOneAndReplace(filter, replacement, options, cancellationToken);
-        }
-
-        public TProjection FindOneAndReplace<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            FindOneAndReplaceOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.FindOneAndReplace(session,
+            return FindOneAndReplaceAsync(session,
                 filter,
                 replacement,
                 options,
                 cancellationToken);
         }
 
-        public Task<TProjection> FindOneAndReplaceAsync<TProjection>(
-            FilterDefinition<T> filter,
-            T replacement,
-            FindOneAndReplaceOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndReplaceAsync(session,
-                    filter,
-                    replacement,
-                    options,
-                    cancellationToken);
-            }
+        return _collection.FindOneAndReplaceAsync(filter,
+            replacement,
+            options,
+            cancellationToken);
+    }
 
-            return _collection.FindOneAndReplaceAsync(filter,
-                replacement,
-                options,
-                cancellationToken);
+    public Task<TProjection> FindOneAndReplaceAsync<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        FindOneAndReplaceOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndReplaceAsync(
+            session,
+            filter,
+            replacement,
+            options,
+            cancellationToken);
+    }
+
+    public TProjection FindOneAndUpdate<TProjection>(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        FindOneAndUpdateOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return FindOneAndUpdate(session, filter, update, options, cancellationToken);
         }
 
-        public Task<TProjection> FindOneAndReplaceAsync<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            FindOneAndReplaceOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.FindOneAndUpdate(filter, update, options, cancellationToken);
+    }
+
+    public TProjection FindOneAndUpdate<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        FindOneAndUpdateOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndUpdate(session,
+            filter,
+            update,
+            options,
+            cancellationToken);
+    }
+
+    public Task<TProjection> FindOneAndUpdateAsync<TProjection>(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        FindOneAndUpdateOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.FindOneAndReplaceAsync(session,
-                filter,
-                replacement,
-                options,
-                cancellationToken);
+            return FindOneAndUpdateAsync(session, filter, update, options, cancellationToken);
         }
 
-        public TProjection FindOneAndUpdate<TProjection>(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            FindOneAndUpdateOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndUpdate(session, filter, update, options, cancellationToken);
-            }
+        return _collection.FindOneAndUpdateAsync(filter, update, options, cancellationToken);
+    }
 
-            return _collection.FindOneAndUpdate(filter, update, options, cancellationToken);
+    public Task<TProjection> FindOneAndUpdateAsync<TProjection>(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        FindOneAndUpdateOptions<T, TProjection>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.FindOneAndUpdateAsync(session,
+            filter,
+            update,
+            options,
+            cancellationToken);
+    }
+
+    public void InsertOne(
+        T document,
+        InsertOneOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            InsertOne(session, document, options, cancellationToken);
+            return;
         }
 
-        public TProjection FindOneAndUpdate<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            FindOneAndUpdateOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
+        _collection.InsertOne(document, options, cancellationToken);
+    }
+
+    public void InsertOne(
+        IClientSessionHandle session,
+        T document,
+        InsertOneOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _collection.InsertOne(session, document, options, cancellationToken);
+    }
+
+    public Task InsertOneAsync(T document, CancellationToken cancellationToken)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.FindOneAndUpdate(session,
-                filter,
-                update,
-                options,
-                cancellationToken);
+            return InsertOneAsync(session, document, cancellationToken: cancellationToken);
         }
 
-        public Task<TProjection> FindOneAndUpdateAsync<TProjection>(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            FindOneAndUpdateOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return FindOneAndUpdateAsync(session, filter, update, options, cancellationToken);
-            }
+        return _collection.InsertOneAsync(document, cancellationToken);
+    }
 
-            return _collection.FindOneAndUpdateAsync(filter, update, options, cancellationToken);
+    public Task InsertOneAsync(
+        T document,
+        InsertOneOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            return InsertOneAsync(session, document, options, cancellationToken);
         }
 
-        public Task<TProjection> FindOneAndUpdateAsync<TProjection>(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            FindOneAndUpdateOptions<T, TProjection>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.InsertOneAsync(document, options, cancellationToken);
+    }
+
+    public Task InsertOneAsync(
+        IClientSessionHandle session,
+        T document,
+        InsertOneOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.InsertOneAsync(session, document, options, cancellationToken);
+    }
+
+    public void InsertMany(
+        IEnumerable<T> documents,
+        InsertManyOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.FindOneAndUpdateAsync(session,
-                filter,
-                update,
-                options,
-                cancellationToken);
-        }
-
-        public void InsertOne(
-            T document,
-            InsertOneOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                InsertOne(session, document, options, cancellationToken);
-                return;
-            }
-
-            _collection.InsertOne(document, options, cancellationToken);
-        }
-
-        public void InsertOne(
-            IClientSessionHandle session,
-            T document,
-            InsertOneOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            _collection.InsertOne(session, document, options, cancellationToken);
-        }
-
-        public Task InsertOneAsync(T document, CancellationToken cancellationToken)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return InsertOneAsync(session, document, cancellationToken: cancellationToken);
-            }
-
-            return _collection.InsertOneAsync(document, cancellationToken);
-        }
-
-        public Task InsertOneAsync(
-            T document,
-            InsertOneOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return InsertOneAsync(session, document, options, cancellationToken);
-            }
-
-            return _collection.InsertOneAsync(document, options, cancellationToken);
-        }
-
-        public Task InsertOneAsync(
-            IClientSessionHandle session,
-            T document,
-            InsertOneOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.InsertOneAsync(session, document, options, cancellationToken);
-        }
-
-        public void InsertMany(
-            IEnumerable<T> documents,
-            InsertManyOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                // ReSharper disable once PossibleMultipleEnumeration
-                InsertMany(session, documents, options, cancellationToken);
-                return;
-            }
-
             // ReSharper disable once PossibleMultipleEnumeration
-            _collection.InsertMany(documents, options, cancellationToken);
+            InsertMany(session, documents, options, cancellationToken);
+            return;
         }
 
-        public void InsertMany(
-            IClientSessionHandle session,
-            IEnumerable<T> documents,
-            InsertManyOptions? options = null,
-            CancellationToken cancellationToken = default)
+        // ReSharper disable once PossibleMultipleEnumeration
+        _collection.InsertMany(documents, options, cancellationToken);
+    }
+
+    public void InsertMany(
+        IClientSessionHandle session,
+        IEnumerable<T> documents,
+        InsertManyOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _collection.InsertMany(session, documents, options, cancellationToken);
+    }
+
+    public Task InsertManyAsync(
+        IEnumerable<T> documents,
+        InsertManyOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            _collection.InsertMany(session, documents, options, cancellationToken);
+            return InsertManyAsync(session, documents, options, cancellationToken);
         }
 
-        public Task InsertManyAsync(
-            IEnumerable<T> documents,
-            InsertManyOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.InsertManyAsync(documents, options, cancellationToken);
+    }
+
+    public Task InsertManyAsync(
+        IClientSessionHandle session,
+        IEnumerable<T> documents,
+        InsertManyOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.InsertManyAsync(session, documents, options, cancellationToken);
+    }
+
+    public IAsyncCursor<TResult> MapReduce<TResult>(
+        BsonJavaScript map,
+        BsonJavaScript reduce,
+        MapReduceOptions<T, TResult>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return InsertManyAsync(session, documents, options, cancellationToken);
-            }
-
-            return _collection.InsertManyAsync(documents, options, cancellationToken);
+            return MapReduce(session, map, reduce, options, cancellationToken);
         }
 
-        public Task InsertManyAsync(
-            IClientSessionHandle session,
-            IEnumerable<T> documents,
-            InsertManyOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.MapReduce(map, reduce, options, cancellationToken);
+    }
+
+    public IAsyncCursor<TResult> MapReduce<TResult>(
+        IClientSessionHandle session,
+        BsonJavaScript map,
+        BsonJavaScript reduce,
+        MapReduceOptions<T, TResult>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.MapReduce(session, map, reduce, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TResult>> MapReduceAsync<TResult>(
+        BsonJavaScript map,
+        BsonJavaScript reduce,
+        MapReduceOptions<T, TResult>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.InsertManyAsync(session, documents, options, cancellationToken);
+            return MapReduceAsync(session, map, reduce, options, cancellationToken);
         }
 
-        public IAsyncCursor<TResult> MapReduce<TResult>(
-            BsonJavaScript map,
-            BsonJavaScript reduce,
-            MapReduceOptions<T, TResult>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.MapReduceAsync(map, reduce, options, cancellationToken);
+    }
+
+    public Task<IAsyncCursor<TResult>> MapReduceAsync<TResult>(
+        IClientSessionHandle session,
+        BsonJavaScript map,
+        BsonJavaScript reduce,
+        MapReduceOptions<T, TResult>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.MapReduceAsync(session, map, reduce, options, cancellationToken);
+    }
+
+    public IFilteredMongoCollection<TDerivedDocument> OfType<TDerivedDocument>()
+        where TDerivedDocument : T
+    {
+        return _collection.OfType<TDerivedDocument>().AsTransactionCollection();
+    }
+
+    public ReplaceOneResult ReplaceOne(
+        FilterDefinition<T> filter,
+        T replacement,
+        ReplaceOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return MapReduce(session, map, reduce, options, cancellationToken);
-            }
-
-            return _collection.MapReduce(map, reduce, options, cancellationToken);
+            return ReplaceOne(session, filter, replacement, options, cancellationToken);
         }
 
-        public IAsyncCursor<TResult> MapReduce<TResult>(
-            IClientSessionHandle session,
-            BsonJavaScript map,
-            BsonJavaScript reduce,
-            MapReduceOptions<T, TResult>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.ReplaceOne(filter, replacement, options, cancellationToken);
+    }
+
+    public ReplaceOneResult ReplaceOne(
+        FilterDefinition<T> filter,
+        T replacement,
+        UpdateOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.MapReduce(session, map, reduce, options, cancellationToken);
+            return ReplaceOne(session, filter, replacement, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<TResult>> MapReduceAsync<TResult>(
-            BsonJavaScript map,
-            BsonJavaScript reduce,
-            MapReduceOptions<T, TResult>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.ReplaceOne(filter, replacement, options, cancellationToken);
+    }
+
+    public ReplaceOneResult ReplaceOne(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        ReplaceOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.ReplaceOne(session, filter, replacement, options, cancellationToken);
+    }
+
+    public ReplaceOneResult ReplaceOne(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        UpdateOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.ReplaceOne(session, filter, replacement, options, cancellationToken);
+    }
+
+    public Task<ReplaceOneResult> ReplaceOneAsync(
+        FilterDefinition<T> filter,
+        T replacement,
+        ReplaceOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return MapReduceAsync(session, map, reduce, options, cancellationToken);
-            }
-
-            return _collection.MapReduceAsync(map, reduce, options, cancellationToken);
+            return ReplaceOneAsync(session, filter, replacement, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<TResult>> MapReduceAsync<TResult>(
-            IClientSessionHandle session,
-            BsonJavaScript map,
-            BsonJavaScript reduce,
-            MapReduceOptions<T, TResult>? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.ReplaceOneAsync(filter, replacement, options, cancellationToken);
+    }
+
+    public Task<ReplaceOneResult> ReplaceOneAsync(
+        FilterDefinition<T> filter,
+        T replacement,
+        UpdateOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.MapReduceAsync(session, map, reduce, options, cancellationToken);
+            return ReplaceOneAsync(session, filter, replacement, options, cancellationToken);
         }
 
-        public IFilteredMongoCollection<TDerivedDocument> OfType<TDerivedDocument>()
-            where TDerivedDocument : T
+        return _collection.ReplaceOneAsync(filter, replacement, options, cancellationToken);
+    }
+
+    public Task<ReplaceOneResult> ReplaceOneAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        ReplaceOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.ReplaceOneAsync(session,
+            filter,
+            replacement,
+            options,
+            cancellationToken);
+    }
+
+    public Task<ReplaceOneResult> ReplaceOneAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        T replacement,
+        UpdateOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.ReplaceOneAsync(session,
+            filter,
+            replacement,
+            options,
+            cancellationToken);
+    }
+
+    public UpdateResult UpdateMany(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.OfType<TDerivedDocument>().AsTransactionCollection();
+            return UpdateMany(session, filter, update, options, cancellationToken);
         }
 
-        public ReplaceOneResult ReplaceOne(
-            FilterDefinition<T> filter,
-            T replacement,
-            ReplaceOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.UpdateMany(filter, update, options, cancellationToken);
+    }
+
+    public UpdateResult UpdateMany(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.UpdateMany(session, filter, update, options, cancellationToken);
+    }
+
+    public Task<UpdateResult> UpdateManyAsync(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return ReplaceOne(session, filter, replacement, options, cancellationToken);
-            }
-
-            return _collection.ReplaceOne(filter, replacement, options, cancellationToken);
+            return UpdateManyAsync(session, filter, update, options, cancellationToken);
         }
 
-        public ReplaceOneResult ReplaceOne(
-            FilterDefinition<T> filter,
-            T replacement,
-            UpdateOptions options,
-            CancellationToken cancellationToken = default)
+        return _collection.UpdateManyAsync(filter, update, options, cancellationToken);
+    }
+
+    public Task<UpdateResult> UpdateManyAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.UpdateManyAsync(session, filter, update, options, cancellationToken);
+    }
+
+    public UpdateResult UpdateOne(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return ReplaceOne(session, filter, replacement, options, cancellationToken);
-            }
-
-            return _collection.ReplaceOne(filter, replacement, options, cancellationToken);
+            return UpdateOne(session, filter, update, options, cancellationToken);
         }
 
-        public ReplaceOneResult ReplaceOne(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            ReplaceOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.UpdateOne(filter, update, options, cancellationToken);
+    }
+
+    public UpdateResult UpdateOne(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.UpdateOne(session, filter, update, options, cancellationToken);
+    }
+
+    public Task<UpdateResult> UpdateOneAsync(
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.ReplaceOne(session, filter, replacement, options, cancellationToken);
+            return UpdateOneAsync(session, filter, update, options, cancellationToken);
         }
 
-        public ReplaceOneResult ReplaceOne(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            UpdateOptions options,
-            CancellationToken cancellationToken = default)
+        return _collection.UpdateOneAsync(filter, update, options, cancellationToken);
+    }
+
+    public Task<UpdateResult> UpdateOneAsync(
+        IClientSessionHandle session,
+        FilterDefinition<T> filter,
+        UpdateDefinition<T> update,
+        UpdateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.UpdateOneAsync(session, filter, update, options, cancellationToken);
+    }
+
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            return _collection.ReplaceOne(session, filter, replacement, options, cancellationToken);
+            return Watch(session, pipeline, options, cancellationToken);
         }
 
-        public Task<ReplaceOneResult> ReplaceOneAsync(
-            FilterDefinition<T> filter,
-            T replacement,
-            ReplaceOptions? options = null,
-            CancellationToken cancellationToken = default)
+        return _collection.Watch(pipeline, options, cancellationToken);
+    }
+
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.Watch(session, pipeline, options, cancellationToken);
+    }
+
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return ReplaceOneAsync(session, filter, replacement, options, cancellationToken);
-            }
-
-            return _collection.ReplaceOneAsync(filter, replacement, options, cancellationToken);
+            return WatchAsync(session, pipeline, options, cancellationToken);
         }
 
-        public Task<ReplaceOneResult> ReplaceOneAsync(
-            FilterDefinition<T> filter,
-            T replacement,
-            UpdateOptions options,
-            CancellationToken cancellationToken = default)
+        return _collection.WatchAsync(pipeline, options, cancellationToken);
+    }
+
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _collection.WatchAsync(session, pipeline, options, cancellationToken);
+    }
+
+    public IMongoCollection<T> WithReadConcern(ReadConcern readConcern)
+    {
+        return _collection.WithReadConcern(readConcern).AsTransactionCollection();
+    }
+
+    public IMongoCollection<T> WithReadPreference(ReadPreference readPreference)
+    {
+        return _collection.WithReadPreference(readPreference).AsTransactionCollection();
+    }
+
+    public IMongoCollection<T> WithWriteConcern(WriteConcern writeConcern)
+    {
+        return _collection.WithWriteConcern(writeConcern).AsTransactionCollection();
+    }
+
+    public CollectionNamespace CollectionNamespace => _collection.CollectionNamespace;
+
+    public IMongoDatabase Database => _collection.Database;
+
+    public IBsonSerializer<T> DocumentSerializer => _collection.DocumentSerializer;
+
+    public IMongoIndexManager<T> Indexes => _collection.Indexes;
+
+    public MongoCollectionSettings Settings => _collection.Settings;
+
+    private bool TryGetSession(out IClientSessionHandle sessionHandle)
+    {
+        if (_clientSessionHandle is { } clientSessionHandle)
         {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return ReplaceOneAsync(session, filter, replacement, options, cancellationToken);
-            }
-
-            return _collection.ReplaceOneAsync(filter, replacement, options, cancellationToken);
+            sessionHandle = clientSessionHandle;
+            return true;
         }
 
-        public Task<ReplaceOneResult> ReplaceOneAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            ReplaceOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.ReplaceOneAsync(session,
-                filter,
-                replacement,
-                options,
-                cancellationToken);
-        }
-
-        public Task<ReplaceOneResult> ReplaceOneAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            T replacement,
-            UpdateOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.ReplaceOneAsync(session,
-                filter,
-                replacement,
-                options,
-                cancellationToken);
-        }
-
-        public UpdateResult UpdateMany(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return UpdateMany(session, filter, update, options, cancellationToken);
-            }
-
-            return _collection.UpdateMany(filter, update, options, cancellationToken);
-        }
-
-        public UpdateResult UpdateMany(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.UpdateMany(session, filter, update, options, cancellationToken);
-        }
-
-        public Task<UpdateResult> UpdateManyAsync(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return UpdateManyAsync(session, filter, update, options, cancellationToken);
-            }
-
-            return _collection.UpdateManyAsync(filter, update, options, cancellationToken);
-        }
-
-        public Task<UpdateResult> UpdateManyAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.UpdateManyAsync(session, filter, update, options, cancellationToken);
-        }
-
-        public UpdateResult UpdateOne(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return UpdateOne(session, filter, update, options, cancellationToken);
-            }
-
-            return _collection.UpdateOne(filter, update, options, cancellationToken);
-        }
-
-        public UpdateResult UpdateOne(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.UpdateOne(session, filter, update, options, cancellationToken);
-        }
-
-        public Task<UpdateResult> UpdateOneAsync(
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return UpdateOneAsync(session, filter, update, options, cancellationToken);
-            }
-
-            return _collection.UpdateOneAsync(filter, update, options, cancellationToken);
-        }
-
-        public Task<UpdateResult> UpdateOneAsync(
-            IClientSessionHandle session,
-            FilterDefinition<T> filter,
-            UpdateDefinition<T> update,
-            UpdateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.UpdateOneAsync(session, filter, update, options, cancellationToken);
-        }
-
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return Watch(session, pipeline, options, cancellationToken);
-            }
-
-            return _collection.Watch(pipeline, options, cancellationToken);
-        }
-
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.Watch(session, pipeline, options, cancellationToken);
-        }
-
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return WatchAsync(session, pipeline, options, cancellationToken);
-            }
-
-            return _collection.WatchAsync(pipeline, options, cancellationToken);
-        }
-
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<T>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _collection.WatchAsync(session, pipeline, options, cancellationToken);
-        }
-
-        public IMongoCollection<T> WithReadConcern(ReadConcern readConcern)
-        {
-            return _collection.WithReadConcern(readConcern).AsTransactionCollection();
-        }
-
-        public IMongoCollection<T> WithReadPreference(ReadPreference readPreference)
-        {
-            return _collection.WithReadPreference(readPreference).AsTransactionCollection();
-        }
-
-        public IMongoCollection<T> WithWriteConcern(WriteConcern writeConcern)
-        {
-            return _collection.WithWriteConcern(writeConcern).AsTransactionCollection();
-        }
-
-        public CollectionNamespace CollectionNamespace => _collection.CollectionNamespace;
-
-        public IMongoDatabase Database => _collection.Database;
-
-        public IBsonSerializer<T> DocumentSerializer => _collection.DocumentSerializer;
-
-        public IMongoIndexManager<T> Indexes => _collection.Indexes;
-
-        public MongoCollectionSettings Settings => _collection.Settings;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryGetSession(out IClientSessionHandle sessionHandle) =>
-            TransactionStore.TryGetSession(_collection.Database.Client, out sessionHandle);
+        return TransactionStore.TryGetSession(
+            _collection.Database.Client, out sessionHandle);
     }
 }

--- a/src/Transactions/MongoTransactionDatabase.cs
+++ b/src/Transactions/MongoTransactionDatabase.cs
@@ -1,546 +1,561 @@
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public class MongoTransactionDatabase : IMongoDatabase
 {
-    public class MongoTransactionDatabase : IMongoDatabase
+    private readonly IMongoDatabase _database;
+    private readonly IClientSessionHandle? _clientSessionHandle;
+
+    public MongoTransactionDatabase(IMongoDatabase database)
     {
-        private readonly IMongoDatabase _database;
+        _database = database;
+    }
 
-        public MongoTransactionDatabase(IMongoDatabase database)
+    public MongoTransactionDatabase(
+        IMongoDatabase database,
+        IClientSessionHandle clientSessionHandle)
+    {
+        _database = database;
+        _clientSessionHandle = clientSessionHandle;
+    }
+
+    public IAsyncCursor<TResult> Aggregate<TResult>(
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            _database = database;
+            return Aggregate(session, pipeline, options, cancellationToken);
         }
 
-        public IAsyncCursor<TResult> Aggregate<TResult>(
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return Aggregate(session, pipeline, options, cancellationToken);
-            }
+        return _database.Aggregate(pipeline, options, cancellationToken);
+    }
 
-            return _database.Aggregate(pipeline, options, cancellationToken);
-        }
+    public IAsyncCursor<TResult> Aggregate<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.Aggregate(session, pipeline, options, cancellationToken);
+    }
 
-        public IAsyncCursor<TResult> Aggregate<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _database.Aggregate(session, pipeline, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.AggregateAsync(session, pipeline, options, cancellationToken);
-            }
-
-            return _database.AggregateAsync(pipeline, options, cancellationToken);
-        }
-
-        public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.AggregateAsync(session, pipeline, options, cancellationToken);
         }
 
-        public void AggregateToCollection<TResult>(
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database.AggregateToCollection(session, pipeline, options, cancellationToken);
-                return;
-            }
+        return _database.AggregateAsync(pipeline, options, cancellationToken);
+    }
 
-            _database.AggregateToCollection(pipeline, options, cancellationToken);
-        }
+    public Task<IAsyncCursor<TResult>> AggregateAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.AggregateAsync(session, pipeline, options, cancellationToken);
+    }
 
-        public void AggregateToCollection<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public void AggregateToCollection<TResult>(
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             _database.AggregateToCollection(session, pipeline, options, cancellationToken);
+            return;
         }
 
-        public Task AggregateToCollectionAsync<TResult>(
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database
-                    .AggregateToCollectionAsync(session, pipeline, options, cancellationToken);
-            }
+        _database.AggregateToCollection(pipeline, options, cancellationToken);
+    }
 
-            return _database.AggregateToCollectionAsync(pipeline, options, cancellationToken);
-        }
+    public void AggregateToCollection<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _database.AggregateToCollection(session, pipeline, options, cancellationToken);
+    }
 
-        public Task AggregateToCollectionAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<NoPipelineInput, TResult> pipeline,
-            AggregateOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task AggregateToCollectionAsync<TResult>(
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database
                 .AggregateToCollectionAsync(session, pipeline, options, cancellationToken);
         }
 
-        public void CreateCollection(
-            string name,
-            CreateCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database.CreateCollection(session, name, options, cancellationToken);
-                return;
-            }
+        return _database.AggregateToCollectionAsync(pipeline, options, cancellationToken);
+    }
 
-            _database.CreateCollection(name, options, cancellationToken);
-        }
+    public Task AggregateToCollectionAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<NoPipelineInput, TResult> pipeline,
+        AggregateOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database
+            .AggregateToCollectionAsync(session, pipeline, options, cancellationToken);
+    }
 
-        public void CreateCollection(
-            IClientSessionHandle session,
-            string name,
-            CreateCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public void CreateCollection(
+        string name,
+        CreateCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             _database.CreateCollection(session, name, options, cancellationToken);
+            return;
         }
 
-        public Task CreateCollectionAsync(
-            string name,
-            CreateCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.CreateCollectionAsync(session, name, options, cancellationToken);
-            }
+        _database.CreateCollection(name, options, cancellationToken);
+    }
 
-            return _database.CreateCollectionAsync(name, options, cancellationToken);
-        }
+    public void CreateCollection(
+        IClientSessionHandle session,
+        string name,
+        CreateCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _database.CreateCollection(session, name, options, cancellationToken);
+    }
 
-        public Task CreateCollectionAsync(
-            IClientSessionHandle session,
-            string name,
-            CreateCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task CreateCollectionAsync(
+        string name,
+        CreateCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.CreateCollectionAsync(session, name, options, cancellationToken);
         }
 
-        public void CreateView<TDocument, TResult>(
-            string viewName,
-            string viewOn,
-            PipelineDefinition<TDocument, TResult> pipeline,
-            CreateViewOptions<TDocument>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database
-                    .CreateView(session, viewName, viewOn, pipeline, options, cancellationToken);
-                return;
-            }
+        return _database.CreateCollectionAsync(name, options, cancellationToken);
+    }
 
-            _database.CreateView(viewName, viewOn, pipeline, options, cancellationToken);
+    public Task CreateCollectionAsync(
+        IClientSessionHandle session,
+        string name,
+        CreateCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.CreateCollectionAsync(session, name, options, cancellationToken);
+    }
+
+    public void CreateView<TDocument, TResult>(
+        string viewName,
+        string viewOn,
+        PipelineDefinition<TDocument, TResult> pipeline,
+        CreateViewOptions<TDocument>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            _database
+                .CreateView(session, viewName, viewOn, pipeline, options, cancellationToken);
+            return;
         }
 
-        public void CreateView<TDocument, TResult>(
-            IClientSessionHandle session,
-            string viewName,
-            string viewOn,
-            PipelineDefinition<TDocument, TResult> pipeline,
-            CreateViewOptions<TDocument>? options = null,
-            CancellationToken cancellationToken = default)
+        _database.CreateView(viewName, viewOn, pipeline, options, cancellationToken);
+    }
+
+    public void CreateView<TDocument, TResult>(
+        IClientSessionHandle session,
+        string viewName,
+        string viewOn,
+        PipelineDefinition<TDocument, TResult> pipeline,
+        CreateViewOptions<TDocument>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _database.CreateView(session, viewName, viewOn, pipeline, options, cancellationToken);
+    }
+
+    public Task CreateViewAsync<TDocument, TResult>(
+        string viewName,
+        string viewOn,
+        PipelineDefinition<TDocument, TResult> pipeline,
+        CreateViewOptions<TDocument>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
-            _database.CreateView(session, viewName, viewOn, pipeline, options, cancellationToken);
+            return _database.CreateViewAsync(
+                session,
+                viewName,
+                viewOn,
+                pipeline,
+                options,
+                cancellationToken);
         }
 
-        public Task CreateViewAsync<TDocument, TResult>(
-            string viewName,
-            string viewOn,
-            PipelineDefinition<TDocument, TResult> pipeline,
-            CreateViewOptions<TDocument>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.CreateViewAsync(
-                    session,
-                    viewName,
-                    viewOn,
-                    pipeline,
-                    options,
-                    cancellationToken);
-            }
+        return _database
+            .CreateViewAsync(viewName, viewOn, pipeline, options, cancellationToken);
+    }
 
-            return _database
-                .CreateViewAsync(viewName, viewOn, pipeline, options, cancellationToken);
+    public Task CreateViewAsync<TDocument, TResult>(
+        IClientSessionHandle session,
+        string viewName,
+        string viewOn,
+        PipelineDefinition<TDocument, TResult> pipeline,
+        CreateViewOptions<TDocument>? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database
+            .CreateViewAsync(session, viewName, viewOn, pipeline, options, cancellationToken);
+    }
+
+    public void DropCollection(
+        string name,
+        DropCollectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
+        {
+            _database.DropCollection(session, name, options, cancellationToken);
+            return;
         }
 
-        public Task CreateViewAsync<TDocument, TResult>(
-            IClientSessionHandle session,
-            string viewName,
-            string viewOn,
-            PipelineDefinition<TDocument, TResult> pipeline,
-            CreateViewOptions<TDocument>? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _database
-                .CreateViewAsync(session, viewName, viewOn, pipeline, options, cancellationToken);
-        }
+        _database.DropCollection(name, options, cancellationToken);
+    }
 
-        public void DropCollection(
-            string name,
-            DropCollectionOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database.DropCollection(session, name, options, cancellationToken);
-                return;
-            }
+    public void DropCollection(
+        IClientSessionHandle session,
+        string name,
+        DropCollectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        _database.DropCollectionAsync(session, name, options, cancellationToken);
+    }
 
-            _database.DropCollection(name, options, cancellationToken);
-        }
-
-        public void DropCollection(
-            IClientSessionHandle session,
-            string name,
-            DropCollectionOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            _database.DropCollectionAsync(session, name, options, cancellationToken);
-        }
-
-        public Task DropCollectionAsync(
-            string name,
-            DropCollectionOptions options,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.DropCollectionAsync(session, name, options, cancellationToken);
-            }
-
-            return _database.DropCollectionAsync(name, options, cancellationToken);
-        }
-
-        public Task DropCollectionAsync(
-            IClientSessionHandle session,
-            string name,
-            DropCollectionOptions options,
-            CancellationToken cancellationToken = default)
+    public Task DropCollectionAsync(
+        string name,
+        DropCollectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.DropCollectionAsync(session, name, options, cancellationToken);
         }
 
-        public void DropCollection(string name, CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database.DropCollection(session, name, cancellationToken);
-                return;
-            }
+        return _database.DropCollectionAsync(name, options, cancellationToken);
+    }
 
-            _database.DropCollection(name, cancellationToken);
-        }
+    public Task DropCollectionAsync(
+        IClientSessionHandle session,
+        string name,
+        DropCollectionOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.DropCollectionAsync(session, name, options, cancellationToken);
+    }
 
-        public void DropCollection(
-            IClientSessionHandle session,
-            string name,
-            CancellationToken cancellationToken = default)
+    public void DropCollection(string name, CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             _database.DropCollection(session, name, cancellationToken);
+            return;
         }
 
-        public Task DropCollectionAsync(
-            string name,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.DropCollectionAsync(session, name, cancellationToken);
-            }
+        _database.DropCollection(name, cancellationToken);
+    }
 
-            return _database.DropCollectionAsync(name, cancellationToken);
-        }
+    public void DropCollection(
+        IClientSessionHandle session,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        _database.DropCollection(session, name, cancellationToken);
+    }
 
-        public Task DropCollectionAsync(
-            IClientSessionHandle session,
-            string name,
-            CancellationToken cancellationToken = default)
+    public Task DropCollectionAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.DropCollectionAsync(session, name, cancellationToken);
         }
 
-        public IMongoCollection<TDocument> GetCollection<TDocument>(
-            string name,
-            MongoCollectionSettings? settings = null)
-        {
-            return _database.GetCollection<TDocument>(name, settings).AsTransactionCollection();
-        }
+        return _database.DropCollectionAsync(name, cancellationToken);
+    }
 
-        public IAsyncCursor<string> ListCollectionNames(
-            ListCollectionNamesOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.ListCollectionNames(session, options, cancellationToken);
-            }
+    public Task DropCollectionAsync(
+        IClientSessionHandle session,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.DropCollectionAsync(session, name, cancellationToken);
+    }
 
-            return _database.ListCollectionNames(options, cancellationToken);
-        }
+    public IMongoCollection<TDocument> GetCollection<TDocument>(
+        string name,
+        MongoCollectionSettings? settings = null)
+    {
+        return _database.GetCollection<TDocument>(name, settings).AsTransactionCollection();
+    }
 
-        public IAsyncCursor<string> ListCollectionNames(
-            IClientSessionHandle session,
-            ListCollectionNamesOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public IAsyncCursor<string> ListCollectionNames(
+        ListCollectionNamesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.ListCollectionNames(session, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<string>> ListCollectionNamesAsync(
-            ListCollectionNamesOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.ListCollectionNamesAsync(session, options, cancellationToken);
-            }
+        return _database.ListCollectionNames(options, cancellationToken);
+    }
 
-            return _database.ListCollectionNamesAsync(options, cancellationToken);
-        }
+    public IAsyncCursor<string> ListCollectionNames(
+        IClientSessionHandle session,
+        ListCollectionNamesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.ListCollectionNames(session, options, cancellationToken);
+    }
 
-        public Task<IAsyncCursor<string>> ListCollectionNamesAsync(
-            IClientSessionHandle session,
-            ListCollectionNamesOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IAsyncCursor<string>> ListCollectionNamesAsync(
+        ListCollectionNamesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.ListCollectionNamesAsync(session, options, cancellationToken);
         }
 
-        public IAsyncCursor<BsonDocument> ListCollections(
-            ListCollectionsOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.ListCollections(session, options, cancellationToken);
-            }
+        return _database.ListCollectionNamesAsync(options, cancellationToken);
+    }
 
-            return _database.ListCollections(options, cancellationToken);
-        }
+    public Task<IAsyncCursor<string>> ListCollectionNamesAsync(
+        IClientSessionHandle session,
+        ListCollectionNamesOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.ListCollectionNamesAsync(session, options, cancellationToken);
+    }
 
-        public IAsyncCursor<BsonDocument> ListCollections(
-            IClientSessionHandle session,
-            ListCollectionsOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public IAsyncCursor<BsonDocument> ListCollections(
+        ListCollectionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.ListCollections(session, options, cancellationToken);
         }
 
-        public Task<IAsyncCursor<BsonDocument>> ListCollectionsAsync(
-            ListCollectionsOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.ListCollectionsAsync(session, options, cancellationToken);
-            }
+        return _database.ListCollections(options, cancellationToken);
+    }
 
-            return _database.ListCollectionsAsync(options, cancellationToken);
-        }
+    public IAsyncCursor<BsonDocument> ListCollections(
+        IClientSessionHandle session,
+        ListCollectionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.ListCollections(session, options, cancellationToken);
+    }
 
-        public Task<IAsyncCursor<BsonDocument>> ListCollectionsAsync(
-            IClientSessionHandle session,
-            ListCollectionsOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IAsyncCursor<BsonDocument>> ListCollectionsAsync(
+        ListCollectionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.ListCollectionsAsync(session, options, cancellationToken);
         }
 
-        public void RenameCollection(
-            string oldName,
-            string newName,
-            RenameCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                _database.RenameCollection(session, oldName, newName, options, cancellationToken);
-                return;
-            }
+        return _database.ListCollectionsAsync(options, cancellationToken);
+    }
 
-            _database.RenameCollection(oldName, newName, options, cancellationToken);
-        }
+    public Task<IAsyncCursor<BsonDocument>> ListCollectionsAsync(
+        IClientSessionHandle session,
+        ListCollectionsOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.ListCollectionsAsync(session, options, cancellationToken);
+    }
 
-        public void RenameCollection(
-            IClientSessionHandle session,
-            string oldName,
-            string newName,
-            RenameCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public void RenameCollection(
+        string oldName,
+        string newName,
+        RenameCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             _database.RenameCollection(session, oldName, newName, options, cancellationToken);
+            return;
         }
 
-        public Task RenameCollectionAsync(
-            string oldName,
-            string newName,
-            RenameCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database
-                    .RenameCollectionAsync(session, oldName, newName, options, cancellationToken);
-            }
+        _database.RenameCollection(oldName, newName, options, cancellationToken);
+    }
 
-            return _database.RenameCollectionAsync(oldName, newName, options, cancellationToken);
-        }
+    public void RenameCollection(
+        IClientSessionHandle session,
+        string oldName,
+        string newName,
+        RenameCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _database.RenameCollection(session, oldName, newName, options, cancellationToken);
+    }
 
-        public Task RenameCollectionAsync(
-            IClientSessionHandle session,
-            string oldName,
-            string newName,
-            RenameCollectionOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task RenameCollectionAsync(
+        string oldName,
+        string newName,
+        RenameCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database
                 .RenameCollectionAsync(session, oldName, newName, options, cancellationToken);
         }
 
-        public TResult RunCommand<TResult>(
-            Command<TResult> command,
-            ReadPreference? readPreference = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.RunCommand(session, command, readPreference, cancellationToken);
-            }
+        return _database.RenameCollectionAsync(oldName, newName, options, cancellationToken);
+    }
 
-            return _database.RunCommand(command, readPreference, cancellationToken);
-        }
+    public Task RenameCollectionAsync(
+        IClientSessionHandle session,
+        string oldName,
+        string newName,
+        RenameCollectionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database
+            .RenameCollectionAsync(session, oldName, newName, options, cancellationToken);
+    }
 
-        public TResult RunCommand<TResult>(
-            IClientSessionHandle session,
-            Command<TResult> command,
-            ReadPreference? readPreference = null,
-            CancellationToken cancellationToken = default)
+    public TResult RunCommand<TResult>(
+        Command<TResult> command,
+        ReadPreference? readPreference = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.RunCommand(session, command, readPreference, cancellationToken);
         }
 
-        public Task<TResult> RunCommandAsync<TResult>(
-            Command<TResult> command,
-            ReadPreference? readPreference = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _database.RunCommandAsync(command, readPreference, cancellationToken);
-        }
+        return _database.RunCommand(command, readPreference, cancellationToken);
+    }
 
-        public Task<TResult> RunCommandAsync<TResult>(
-            IClientSessionHandle session,
-            Command<TResult> command,
-            ReadPreference? readPreference = null,
-            CancellationToken cancellationToken = default)
-        {
-            return _database.RunCommandAsync(session, command, readPreference, cancellationToken);
-        }
+    public TResult RunCommand<TResult>(
+        IClientSessionHandle session,
+        Command<TResult> command,
+        ReadPreference? readPreference = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.RunCommand(session, command, readPreference, cancellationToken);
+    }
 
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.Watch(session, pipeline, options, cancellationToken);
-            }
+    public Task<TResult> RunCommandAsync<TResult>(
+        Command<TResult> command,
+        ReadPreference? readPreference = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.RunCommandAsync(command, readPreference, cancellationToken);
+    }
 
-            return _database.Watch(pipeline, options, cancellationToken);
-        }
+    public Task<TResult> RunCommandAsync<TResult>(
+        IClientSessionHandle session,
+        Command<TResult> command,
+        ReadPreference? readPreference = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.RunCommandAsync(session, command, readPreference, cancellationToken);
+    }
 
-        public IChangeStreamCursor<TResult> Watch<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.Watch(session, pipeline, options, cancellationToken);
         }
 
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (TryGetSession(out IClientSessionHandle? session))
-            {
-                return _database.WatchAsync(session, pipeline, options, cancellationToken);
-            }
+        return _database.Watch(pipeline, options, cancellationToken);
+    }
 
-            return _database.WatchAsync(pipeline, options, cancellationToken);
-        }
+    public IChangeStreamCursor<TResult> Watch<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.Watch(session, pipeline, options, cancellationToken);
+    }
 
-        public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
-            IClientSessionHandle session,
-            PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
-            ChangeStreamOptions? options = null,
-            CancellationToken cancellationToken = default)
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (TryGetSession(out IClientSessionHandle? session))
         {
             return _database.WatchAsync(session, pipeline, options, cancellationToken);
         }
 
-        public IMongoDatabase WithReadConcern(ReadConcern readConcern)
-        {
-            return _database.WithReadConcern(readConcern).AsTransactionDatabase();
-        }
-
-        public IMongoDatabase WithReadPreference(ReadPreference readPreference)
-        {
-            return _database.WithReadPreference(readPreference).AsTransactionDatabase();
-        }
-
-        public IMongoDatabase WithWriteConcern(WriteConcern writeConcern)
-        {
-            return _database.WithWriteConcern(writeConcern).AsTransactionDatabase();
-        }
-
-        public IMongoClient Client => _database.Client;
-
-        public DatabaseNamespace DatabaseNamespace => _database.DatabaseNamespace;
-
-        public MongoDatabaseSettings Settings => _database.Settings;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryGetSession(out IClientSessionHandle sessionHandle) =>
-            TransactionStore.TryGetSession(_database.Client, out sessionHandle);
+        return _database.WatchAsync(pipeline, options, cancellationToken);
     }
+
+    public Task<IChangeStreamCursor<TResult>> WatchAsync<TResult>(
+        IClientSessionHandle session,
+        PipelineDefinition<ChangeStreamDocument<BsonDocument>, TResult> pipeline,
+        ChangeStreamOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return _database.WatchAsync(session, pipeline, options, cancellationToken);
+    }
+
+    public IMongoDatabase WithReadConcern(ReadConcern readConcern)
+    {
+        return _database.WithReadConcern(readConcern).AsTransactionDatabase();
+    }
+
+    public IMongoDatabase WithReadPreference(ReadPreference readPreference)
+    {
+        return _database.WithReadPreference(readPreference).AsTransactionDatabase();
+    }
+
+    public IMongoDatabase WithWriteConcern(WriteConcern writeConcern)
+    {
+        return _database.WithWriteConcern(writeConcern).AsTransactionDatabase();
+    }
+
+    public IMongoClient Client => _database.Client;
+
+    public DatabaseNamespace DatabaseNamespace => _database.DatabaseNamespace;
+
+    public MongoDatabaseSettings Settings => _database.Settings;
+
+    private bool TryGetSession(out IClientSessionHandle sessionHandle)
+    {
+        if (_clientSessionHandle is { } clientSessionHandle)
+        {
+            sessionHandle = clientSessionHandle;
+            return true;
+        }
+
+        return TransactionStore.TryGetSession(
+            _database.Client, out sessionHandle);
+    }        
 }

--- a/src/Transactions/MongoTransactionFilteredCollection.cs
+++ b/src/Transactions/MongoTransactionFilteredCollection.cs
@@ -1,19 +1,27 @@
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public class MongoTransactionFilteredCollection<T>
+    : MongoTransactionCollection<T>
+    , IFilteredMongoCollection<T>
 {
-    public class MongoTransactionFilteredCollection<T>
-        : MongoTransactionCollection<T>
-        , IFilteredMongoCollection<T>
+    private readonly IFilteredMongoCollection<T> _filteredCollection;
+
+    public MongoTransactionFilteredCollection(
+        IFilteredMongoCollection<T> filteredCollection)
+        : base(filteredCollection)
     {
-        private readonly IFilteredMongoCollection<T> _filteredCollection;
-
-        public MongoTransactionFilteredCollection(IFilteredMongoCollection<T> filteredCollection)
-            : base(filteredCollection)
-        {
-            _filteredCollection = filteredCollection;
-        }
-
-        public FilterDefinition<T> Filter => _filteredCollection.Filter;
+        _filteredCollection = filteredCollection;
     }
+
+    public MongoTransactionFilteredCollection(
+        IFilteredMongoCollection<T> filteredCollection,
+        IClientSessionHandle clientSessionHandle)
+        : base(filteredCollection, clientSessionHandle)
+    {
+        _filteredCollection = filteredCollection;
+    }
+
+    public FilterDefinition<T> Filter => _filteredCollection.Filter;
 }

--- a/src/Transactions/TransactionClientExtensions.cs
+++ b/src/Transactions/TransactionClientExtensions.cs
@@ -1,12 +1,19 @@
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public static class TransactionClientExtensions
 {
-    public static class TransactionClientExtensions
+    public static IMongoClient AsTransactionClient(
+        this IMongoClient collection)
     {
-        public static IMongoClient AsTransactionClient(this IMongoClient collection)
-        {
-            return new MongoTransactionClient(collection);
-        }
+        return new MongoTransactionClient(collection);
+    }
+
+    public static IMongoClient AsTransactionClient(
+        this IMongoClient collection,
+        IClientSessionHandle clientSessionHandle)
+    {
+        return new MongoTransactionClient(collection, clientSessionHandle);
     }
 }

--- a/src/Transactions/TransactionCollectionExtensions.cs
+++ b/src/Transactions/TransactionCollectionExtensions.cs
@@ -1,19 +1,32 @@
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
-{
-    public static class TransactionCollectionExtensions
-    {
-        public static IMongoCollection<T> AsTransactionCollection<T>(
-            this IMongoCollection<T> collection)
-        {
-            return new MongoTransactionCollection<T>(collection);
-        }
+namespace MongoDB.Extensions.Transactions;
 
-        public static IFilteredMongoCollection<T> AsTransactionCollection<T>(
-            this IFilteredMongoCollection<T> collection)
-        {
-            return new MongoTransactionFilteredCollection<T>(collection);
-        }
+public static class TransactionCollectionExtensions
+{
+    public static IMongoCollection<T> AsTransactionCollection<T>(
+        this IMongoCollection<T> collection)
+    {
+        return new MongoTransactionCollection<T>(collection);
+    }
+
+    public static IMongoCollection<T> AsTransactionCollection<T>(
+        this IMongoCollection<T> collection,
+        IClientSessionHandle clientSessionHandle)
+    {
+        return new MongoTransactionCollection<T>(collection, clientSessionHandle);
+    }
+
+    public static IFilteredMongoCollection<T> AsTransactionCollection<T>(
+        this IFilteredMongoCollection<T> collection)
+    {
+        return new MongoTransactionFilteredCollection<T>(collection);
+    }
+
+    public static IFilteredMongoCollection<T> AsTransactionCollection<T>(
+        this IFilteredMongoCollection<T> collection,
+        IClientSessionHandle clientSessionHandle)
+    {
+        return new MongoTransactionFilteredCollection<T>(collection, clientSessionHandle);
     }
 }

--- a/src/Transactions/TransactionDatabaseExtensions.cs
+++ b/src/Transactions/TransactionDatabaseExtensions.cs
@@ -1,12 +1,19 @@
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+public static class TransactionDatabaseExtensions
 {
-    public static class TransactionDatabaseExtensions
+    public static IMongoDatabase AsTransactionDatabase(
+        this IMongoDatabase collection)
     {
-        public static IMongoDatabase AsTransactionDatabase(this IMongoDatabase collection)
-        {
-            return new MongoTransactionDatabase(collection);
-        }
+        return new MongoTransactionDatabase(collection);
+    }
+
+    public static IMongoDatabase AsTransactionDatabase(
+        this IMongoDatabase collection,
+        IClientSessionHandle clientSessionHandle)
+    {
+        return new MongoTransactionDatabase(collection, clientSessionHandle);
     }
 }

--- a/src/Transactions/TransactionStore.cs
+++ b/src/Transactions/TransactionStore.cs
@@ -2,55 +2,54 @@ using System.Collections.Concurrent;
 using System.Transactions;
 using MongoDB.Driver;
 
-namespace MongoDB.Extensions.Transactions
+namespace MongoDB.Extensions.Transactions;
+
+internal static class TransactionStore
 {
-    internal static class TransactionStore
+    private static readonly ConcurrentDictionary<string, IClientSessionHandle>
+        Sessions = new();
+
+    public static bool TryGetSession(
+        IMongoClient client,
+        out IClientSessionHandle sessionHandle)
     {
-        private static readonly ConcurrentDictionary<string, IClientSessionHandle>
-            Sessions = new();
-
-        public static bool TryGetSession(
-            IMongoClient client,
-            out IClientSessionHandle sessionHandle)
+        if (Transaction.Current?.TransactionInformation.LocalIdentifier is { } id)
         {
-            if (Transaction.Current?.TransactionInformation.LocalIdentifier is { } id)
-            {
-                sessionHandle = GetOrCreateTransaction(client, id);
-                return true;
-            }
-
-            sessionHandle = null!;
-            return false;
+            sessionHandle = GetOrCreateTransaction(client, id);
+            return true;
         }
 
-        private static IClientSessionHandle GetOrCreateTransaction(
-            IMongoClient mongoClient,
-            string id)
+        sessionHandle = null!;
+        return false;
+    }
+
+    private static IClientSessionHandle GetOrCreateTransaction(
+        IMongoClient mongoClient,
+        string id)
+    {
+        return Sessions.GetOrAdd(id, CreateAndRegister);
+
+        IClientSessionHandle CreateAndRegister(string idToRegister)
         {
-            return Sessions.GetOrAdd(id, CreateAndRegister);
-
-            IClientSessionHandle CreateAndRegister(string idToRegister)
+            if (Transaction.Current is null)
             {
-                if (Transaction.Current is null)
+                throw new TransactionException(
+                    "Cannot open a transaction without a valid scope");
+            }
+
+            IClientSessionHandle? session = mongoClient.StartSession();
+            session.StartTransaction();
+            MongoDbEnlistmentScope enlistment = new(session, Unregister);
+
+            Transaction.Current.EnlistVolatile(enlistment, EnlistmentOptions.None);
+
+            return session;
+
+            void Unregister()
+            {
+                if (Sessions.TryRemove(idToRegister, out session))
                 {
-                    throw new TransactionException(
-                        "Cannot open a transaction without a valid scope");
-                }
-
-                IClientSessionHandle? session = mongoClient.StartSession();
-                session.StartTransaction();
-                MongoDbEnlistmentScope enlistment = new(session, Unregister);
-
-                Transaction.Current.EnlistVolatile(enlistment, EnlistmentOptions.None);
-
-                return session;
-
-                void Unregister()
-                {
-                    if (Sessions.TryRemove(idToRegister, out session))
-                    {
-                        session.Dispose();
-                    }
+                    session.Dispose();
                 }
             }
         }


### PR DESCRIPTION
The transactions have been controlled via the TransactionScope. We extended the Transaction- Collection, Database and Client that you can add the transaction session via constructor. If the transaction session is not explicitly set via constructor, then the transaction scope takes over as before.
