### PR TITLE
Upgrade MongoDB.Driver dependency to version 2.21.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion  Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageVersion  Include="MongoDB.Driver" Version="2.21.0" />
     <PackageVersion  Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
     <PackageVersion  Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>

--- a/src/Transactions/MongoTransactionCollection.cs
+++ b/src/Transactions/MongoTransactionCollection.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
+using MongoDB.Driver.Search;
 
 #pragma warning disable 618
 
@@ -1080,6 +1081,8 @@ public class MongoTransactionCollection<T> : IMongoCollection<T>
     public IBsonSerializer<T> DocumentSerializer => _collection.DocumentSerializer;
 
     public IMongoIndexManager<T> Indexes => _collection.Indexes;
+
+    public IMongoSearchIndexManager SearchIndexes => _collection.SearchIndexes;
 
     public MongoCollectionSettings Settings => _collection.Settings;
 


### PR DESCRIPTION
Version 2.21.0 of [MongoDB.Driver][1] introduced a [breaking change][2] by adding a `SearchIndexes` property to the `IMongoCollection` interface.

This commit implements this new property in order to avoid the following exception:

> **System.TypeLoadException**
> Method 'get_SearchIndexes' in type 'MongoDB.Extensions.Transactions.MongoTransactionCollection`1' from assembly 'MongoDB.Extensions.Transactions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.

[1]: https://www.nuget.org/packages/MongoDB.Driver/2.21.0
[2]: https://jira.mongodb.org/browse/CSHARP-4660?focusedCommentId=5628278&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-5628278