### PR TITLE
Misg/outbox

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,38 +25,47 @@
     <PackageVersion  Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
     <PackageVersion  Include="System.Text.Json" Version="7.0.0" />
     <PackageVersion  Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageVersion  Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-    <PackageVersion  Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageVersion  Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageVersion  Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageVersion  Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageVersion  Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MongoDB.Extensions.sln
+++ b/src/MongoDB.Extensions.sln
@@ -27,10 +27,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Migration.Tests", "Migratio
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".SolutionFiles", ".SolutionFiles", "{A21A1FF3-25C1-4FE1-994E-E16CDF98BB99}"
 	ProjectSection(SolutionItems) = preProject
+		..\Directory.Packages.props = ..\Directory.Packages.props
 		TestProject.props = TestProject.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Context.AllowedTypes.Tests", "Context.AllowedTypes.Tests\Context.AllowedTypes.Tests.csproj", "{C59B2068-C3F4-4900-A1CB-7BFD63F94095}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Outbox", "Outbox\Outbox.csproj", "{DA61731E-A164-4EFC-B40C-CFADA88EDF20}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Outbox.Tests", "Outbox.Tests\Outbox.Tests.csproj", "{47201075-0A32-474D-ABD6-5C7D2DEB30EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -86,6 +91,14 @@ Global
 		{C59B2068-C3F4-4900-A1CB-7BFD63F94095}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C59B2068-C3F4-4900-A1CB-7BFD63F94095}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C59B2068-C3F4-4900-A1CB-7BFD63F94095}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA61731E-A164-4EFC-B40C-CFADA88EDF20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA61731E-A164-4EFC-B40C-CFADA88EDF20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA61731E-A164-4EFC-B40C-CFADA88EDF20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA61731E-A164-4EFC-B40C-CFADA88EDF20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47201075-0A32-474D-ABD6-5C7D2DEB30EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47201075-0A32-474D-ABD6-5C7D2DEB30EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47201075-0A32-474D-ABD6-5C7D2DEB30EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47201075-0A32-474D-ABD6-5C7D2DEB30EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Outbox.Tests/Core/ConsumerProxyTests.cs
+++ b/src/Outbox.Tests/Core/ConsumerProxyTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+{
+    public class ConsumerProxyTests
+    {
+        [Fact]
+        public async Task ConsumeAsync_WithValidMessageType_ShouldAcceptConsumption()
+        {
+            //Arrange 
+            var message = new DummyMessage();
+            CancellationToken token = new CancellationTokenSource().Token;
+
+            var consumer = new Mock<IConsumer<DummyMessage>>(MockBehavior.Strict);
+            consumer
+                .Setup(c => c.ConsumeAsync(message, token))
+                .Returns(Task.CompletedTask);
+
+            var proxy = new ConsumerProxy<DummyMessage>(consumer.Object);
+
+            //Act
+            await proxy.ConsumeAsync(message, token);
+
+            //Assert
+            consumer.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ConsumeAsync_WithUnsupportedMessageType_ShouldThrowException()
+        {
+            //Arrange 
+            var message = new object();
+            CancellationToken token = new CancellationTokenSource().Token;
+
+            var consumer = new Mock<IConsumer<DummyMessage>>(MockBehavior.Strict);
+
+            var proxy = new ConsumerProxy<DummyMessage>(consumer.Object);
+
+            //Act
+            Func<Task> tryConsume = async () => await proxy.ConsumeAsync(message, token);
+
+            //Assert
+            await tryConsume.Should().ThrowAsync<UnsupportedMessageTypeException>();
+        }
+
+        public class DummyMessage
+        {
+        }
+    }
+}

--- a/src/Outbox.Tests/Core/ConsumerProxyTests.cs
+++ b/src/Outbox.Tests/Core/ConsumerProxyTests.cs
@@ -3,18 +3,18 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core.Exceptions;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+namespace MongoDB.Extensions.Outbox.Tests.Core
 {
     public class ConsumerProxyTests
     {
         [Fact]
         public async Task ConsumeAsync_WithValidMessageType_ShouldAcceptConsumption()
         {
-            //Arrange 
+            //Arrange
             var message = new DummyMessage();
             CancellationToken token = new CancellationTokenSource().Token;
 
@@ -35,7 +35,7 @@ namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
         [Fact]
         public async Task ConsumeAsync_WithUnsupportedMessageType_ShouldThrowException()
         {
-            //Arrange 
+            //Arrange
             var message = new object();
             CancellationToken token = new CancellationTokenSource().Token;
 

--- a/src/Outbox.Tests/Core/ConsumptionFactoryTests.cs
+++ b/src/Outbox.Tests/Core/ConsumptionFactoryTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+{
+    public class ConsumptionFactoryTests
+    {
+        [Fact]
+        public void Create_ForSupportedMessage_ShouldReturnConsumptionWithProxy()
+        {
+            //Arrange
+            var proxy = new DummyProxy();
+
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+
+            Func<IServiceProvider, DummyProxy> proxyFact = (IServiceProvider p) => proxy;
+
+            var factory = new ConsumptionFactory(
+                provider, new Dictionary<Type, Func<IServiceProvider, IConsumerProxy>>
+                {
+                    { typeof(DummyMessage),  proxyFact }
+                });
+
+            //Act
+            IConsumption job = factory.Create(new DummyMessage());
+
+            //Assert
+            job.Should().BeOfType<Consumption<DummyMessage>>()
+                .Subject.ConsumerProxy.Should().Be(proxy);
+        }
+
+        [Fact]
+        public void Create_ForUnsupportedMessage_ShouldThrow()
+        {
+            //Arrange
+            var services = new ServiceCollection();
+            IServiceProvider provider = services.BuildServiceProvider();
+
+            Func<IServiceProvider, DummyProxy> proxyFact = (IServiceProvider p)
+                => new DummyProxy();
+
+            var factory = new ConsumptionFactory(
+                provider, new Dictionary<Type, Func<IServiceProvider, IConsumerProxy>>
+                {
+                    { typeof(DummyMessage),  proxyFact }
+                });
+
+            //Act
+            Func<IConsumption> tryGetConsumption = () => factory.Create(new object());
+
+            //Assert
+            tryGetConsumption.Should().Throw<KeyNotFoundException>();
+        }
+
+        public class DummyMessage
+        {
+        }
+
+        public class DummyProxy : IConsumerProxy
+        {
+            public Task ConsumeAsync(object message, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Outbox.Tests/Core/ConsumptionFactoryTests.cs
+++ b/src/Outbox.Tests/Core/ConsumptionFactoryTests.cs
@@ -4,10 +4,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+namespace MongoDB.Extensions.Outbox.Tests.Core
 {
     public class ConsumptionFactoryTests
     {

--- a/src/Outbox.Tests/Core/ConsumptionTests.cs
+++ b/src/Outbox.Tests/Core/ConsumptionTests.cs
@@ -1,17 +1,17 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+namespace MongoDB.Extensions.Outbox.Tests.Core
 {
     public class ConsumptionTests
     {
         [Fact]
         public async Task ConsumeAsync_WithMessage_ShouldForwardToProxy()
         {
-            //Arrange 
+            //Arrange
             var message = new DummyMessage();
             CancellationToken token = new CancellationTokenSource().Token;
 

--- a/src/Outbox.Tests/Core/ConsumptionTests.cs
+++ b/src/Outbox.Tests/Core/ConsumptionTests.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+{
+    public class ConsumptionTests
+    {
+        [Fact]
+        public async Task ConsumeAsync_WithMessage_ShouldForwardToProxy()
+        {
+            //Arrange 
+            var message = new DummyMessage();
+            CancellationToken token = new CancellationTokenSource().Token;
+
+            var proxy = new Mock<IConsumerProxy<DummyMessage>>(MockBehavior.Strict);
+            proxy
+                .Setup(c => c.ConsumeAsync(message, token))
+                .Returns(Task.CompletedTask);
+
+            var consumption = new Consumption<DummyMessage>(proxy.Object, message);
+
+            //Act
+            await consumption.ConsumeAsync(token);
+
+            //Assert
+            proxy.VerifyAll();
+        }
+
+        public class DummyMessage
+        {
+        }
+    }
+}

--- a/src/Outbox.Tests/Core/OutboxServiceCollectionExtensionsTests.cs
+++ b/src/Outbox.Tests/Core/OutboxServiceCollectionExtensionsTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+{
+    public class OutboxServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddTransactionalOutbox_WithOptions_ShouldRegisterServiceAndHostedService()
+        {
+            //Arrange
+            var services = new ServiceCollection();
+
+            var options = new OutboxOptions();
+
+            //Act
+            services.AddTransactionalOutbox(options);
+
+            //Assert
+            services.Should().ContainSingle(s => s.ServiceType== typeof(OutboxOptions))
+                .Which.Lifetime.Should().Be(ServiceLifetime.Singleton);
+            services.Should().ContainSingle(s => s.ServiceType== typeof(IOutboxService))
+                .Which.ImplementationType.Should().Be(typeof(OutboxService));
+            services.Should().ContainSingle(s => s.ServiceType== typeof(IMessageProcessor))
+                .Which.ImplementationType.Should().Be(typeof(MessageProcessor));
+            services.Should().ContainSingle(s => s.ServiceType== typeof(IHostedService))
+                .Which.ImplementationType.Should().Be(typeof(MessagesDeliveryService));
+        }
+    }
+}

--- a/src/Outbox.Tests/Core/OutboxServiceCollectionExtensionsTests.cs
+++ b/src/Outbox.Tests/Core/OutboxServiceCollectionExtensionsTests.cs
@@ -1,10 +1,10 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+namespace MongoDB.Extensions.Outbox.Tests.Core
 {
     public class OutboxServiceCollectionExtensionsTests
     {

--- a/src/Outbox.Tests/Core/OutboxServiceTests.cs
+++ b/src/Outbox.Tests/Core/OutboxServiceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+{
+    public class OutboxServiceTests
+    {
+        [Fact]
+        public async Task AddMessagesAsync_WithPayloads_ShouldAddMessagesToRepository()
+        {
+            //Arrange
+            CancellationToken token = new CancellationTokenSource().Token;
+            var payloads = new object[] { new object() };
+
+            var transactionSection = new Mock<ITransactionSession>(MockBehavior.Strict);
+
+            var repository = new Mock<IOutboxRepository>(MockBehavior.Strict);
+            repository
+                .Setup(r => r.AddMessagesAsync(
+                    transactionSection.Object,
+                    It.Is<IReadOnlyList<OutboxMessage>>(l => l.Count == payloads.Count()
+                        && l.All(i => payloads.Contains(i.Payload))),
+                    token))
+                .Returns(Task.CompletedTask);
+
+            var service = new OutboxService(repository.Object);
+
+            //Act
+            await service.AddMessagesAsync(transactionSection.Object, payloads, token);
+
+            //Assert
+            repository.VerifyAll();
+        }
+    }
+}

--- a/src/Outbox.Tests/Core/OutboxServiceTests.cs
+++ b/src/Outbox.Tests/Core/OutboxServiceTests.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Core
+namespace MongoDB.Extensions.Outbox.Tests.Core
 {
     public class OutboxServiceTests
     {

--- a/src/Outbox.Tests/Outbox.Tests.csproj
+++ b/src/Outbox.Tests/Outbox.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Outbox\Outbox.csproj" />
   </ItemGroup>
 

--- a/src/Outbox.Tests/Outbox.Tests.csproj
+++ b/src/Outbox.Tests/Outbox.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCTestProjectProps)" Condition="Exists('$(CCTestProjectProps)')" />
+
+  <PropertyGroup>
+    <AssemblyName>MongoDB.Extensions.Outbox.Tests</AssemblyName>
+    <RootNamespace>MongoDB.Extensions.Outbox.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Outbox\Outbox.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Outbox.Tests/Persistence/MongoDBLockProviderTests.cs
+++ b/src/Outbox.Tests/Persistence/MongoDBLockProviderTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Driver;
+using MongoDB.Extensions.Context;
+using Snapshooter.Xunit;
+using Squadron;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Persistence
+{
+    public class MongoDBLockProviderTests : IClassFixture<MongoReplicaSetResource>
+    {
+        private readonly OutboxDbContext _dbContext;
+        private readonly IMongoCollection<MessageLock> _collection;
+
+        public MongoDBLockProviderTests(MongoReplicaSetResource mongoRsResource)
+        {
+            IMongoDatabase mongoDatabase = mongoRsResource.CreateDatabase();
+            mongoRsResource.Client.DisableTableScan();
+
+            var mongoOptions = new MongoOptions
+            {
+                ConnectionString = mongoRsResource.ConnectionString,
+                DatabaseName = mongoDatabase.DatabaseNamespace.DatabaseName
+            };
+            _dbContext = new OutboxDbContext(
+                mongoOptions,
+                new MessageOptions { LockDuration = TimeSpan.FromSeconds(15) });
+            _dbContext.Initialize();
+            _collection = _dbContext.CreateCollection<MessageLock>();
+        }
+
+        [Fact]
+        public async Task AcquireMessageLockAsync_WithoutExistingLockInDb_ShouldAcquireLock()
+        {
+            //Arrange
+            Guid messageId = Guid.NewGuid();
+            CancellationToken token = new CancellationTokenSource().Token;
+
+            var provider = new MongoDBLockProvider(_dbContext);
+
+            //Act
+            bool acquired = await provider.AcquireMessageLockAsync(messageId, token);
+
+            //Assert
+            acquired.Should().BeTrue();
+            MessageLock createdLock
+                = await _collection.Find(Builders<MessageLock>.Filter.Empty).SingleAsync();
+            createdLock.Id.Should().Be(messageId);
+            createdLock.LockedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+        }
+
+        [Fact]
+        public async Task AcquireMessageLockAsync_WithExistingLockInDb_ShouldNotAcquireLock()
+        {
+            //Arrange
+            Guid messageId = Guid.NewGuid();
+            CancellationToken token = new CancellationTokenSource().Token;
+            var existingLock = new MessageLock(messageId, DateTime.UtcNow);
+            await _collection.InsertOneAsync(existingLock);
+
+            var provider = new MongoDBLockProvider(_dbContext);
+
+            //Act
+            bool acquired = await provider.AcquireMessageLockAsync(messageId, token);
+
+            //Assert
+            acquired.Should().BeFalse();
+            MessageLock createdLock
+                = await _collection.Find(Builders<MessageLock>.Filter.Empty).SingleAsync();
+            createdLock.Id.Should().Be(existingLock.Id);
+            createdLock.LockedAt.Should().BeCloseTo(existingLock.LockedAt, TimeSpan.FromMilliseconds(1));
+        }
+
+        [Fact]
+        public async Task Ctor_WithDbContext_ShouldGetLockCollectionWithTTLIndex()
+        {
+            //Arrange
+            CancellationToken token = new CancellationTokenSource().Token;
+
+            //Act
+            IReadOnlyList<global::MongoDB.Bson.BsonDocument> indexes
+                = (await _collection.Indexes.ListAsync(token)).ToList();
+
+            //Assert
+            indexes.Should().Contain(
+                i => i["key"].AsBsonDocument.Contains("LockedAt")
+                && i["key"]["LockedAt"] == 1
+                && i["name"] == "LockedAt_1"
+                && i["expireAfterSeconds"] == 15);
+        }
+    }
+}

--- a/src/Outbox.Tests/Persistence/MongoDBLockProviderTests.cs
+++ b/src/Outbox.Tests/Persistence/MongoDBLockProviderTests.cs
@@ -7,11 +7,11 @@ using MongoDB.Driver;
 using MongoDB.Extensions.Context;
 using Snapshooter.Xunit;
 using Squadron;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Persistence;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Persistence
+namespace MongoDB.Extensions.Outbox.Tests.Persistence
 {
     public class MongoDBLockProviderTests : IClassFixture<MongoReplicaSetResource>
     {

--- a/src/Outbox.Tests/Persistence/OutboxRepositoryTests.cs
+++ b/src/Outbox.Tests/Persistence/OutboxRepositoryTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Driver;
+using MongoDB.Extensions.Context;
+using Squadron;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+using Xunit;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Persistence
+{
+    public class OutboxRepositoryTests : IClassFixture<MongoReplicaSetResource>
+    {
+        private readonly OutboxDbContext _dbContext;
+        private readonly MongoSessionProvider _sessionProvider;
+        private readonly IMongoCollection<OutboxMessage> _collection;
+
+        public OutboxRepositoryTests(MongoReplicaSetResource mongoRsResource)
+        {
+            IMongoDatabase mongoDatabase = mongoRsResource.CreateDatabase();
+            mongoRsResource.Client.DisableTableScan();
+
+            var mongoOptions = new MongoOptions
+            {
+                ConnectionString = mongoRsResource.ConnectionString,
+                DatabaseName = mongoDatabase.DatabaseNamespace.DatabaseName
+            };
+            _dbContext = new OutboxDbContext(
+                mongoOptions,
+                new MessageOptions { LockDuration = TimeSpan.FromSeconds(30) });
+            _dbContext.Initialize();
+
+            _sessionProvider = new MongoSessionProvider(_dbContext);
+
+            _collection = _dbContext.CreateCollection<OutboxMessage>();
+        }
+
+        [Fact]
+        public async Task GetPendingMessagesAsync_WithMessagesOlderThanMinimumAge_ShouldReturnTheseMessages()
+        {
+            //Arrange testData
+            var message = new OutboxMessage(
+                id: Guid.NewGuid(),
+                payload: new DummyPayload(Guid.NewGuid()),
+                creationDate: DateTime.UtcNow.AddSeconds(-31)
+            );
+            await _collection.InsertOneAsync(message, new InsertOneOptions(), CancellationToken.None);
+
+            //Arrange dependencies
+            var options = new OutboxOptions
+            {
+                FallbackWorker = new OutboxFallBackWorkerOptions
+                {
+                    MessageMinimumAge = TimeSpan.FromSeconds(30)
+                }
+            };
+
+            var repository = new OutboxRepository(options, _dbContext, _sessionProvider);
+
+            //Act
+            IReadOnlyList<OutboxMessage> messages
+                = await repository.GetPendingMessagesAsync(CancellationToken.None);
+
+            //Assert
+            OutboxMessage foundMessage = messages.Should().ContainSingle().Subject;
+            foundMessage.Id.Should().Be(message.Id);
+            DummyPayload foundPayload = foundMessage.Payload.Should().BeOfType<DummyPayload>().Subject;
+            foundPayload.Should().BeEquivalentTo(message.Payload as DummyPayload);
+        }
+
+        [Fact]
+        public async Task GetPendingMessagesAsync_WithMessagesYoungerThanMinimumAge_ShouldNotReturnTheseMessages()
+        {
+            //Arrange testData
+            var message = new OutboxMessage(
+                id: Guid.NewGuid(),
+                payload: new DummyPayload(Guid.NewGuid()),
+                creationDate: DateTime.UtcNow
+            );
+            await _collection.InsertOneAsync(message, new InsertOneOptions(), CancellationToken.None);
+
+            //Arrange dependencies
+            var options = new OutboxOptions
+            {
+                FallbackWorker = new OutboxFallBackWorkerOptions
+                {
+                    MessageMinimumAge = TimeSpan.FromSeconds(30)
+                }
+            };
+
+            var repository = new OutboxRepository(options, _dbContext, _sessionProvider);
+
+            //Act
+            IReadOnlyList<OutboxMessage> messages
+                = await repository.GetPendingMessagesAsync(CancellationToken.None);
+
+            //Assert
+            messages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task BeginTransactionAsync_ShouldAlwaysReturnMongoSessionWithOpenTransaction()
+        {
+            //Arrange
+            var options = new OutboxOptions
+            {
+                FallbackWorker = new OutboxFallBackWorkerOptions
+                {
+                    MessageMinimumAge = TimeSpan.FromSeconds(30)
+                }
+            };
+
+            var repository = new OutboxRepository(options, _dbContext, _sessionProvider);
+
+            //Act
+            ITransactionSession transactionSession
+                = await repository.BeginTransactionAsync(CancellationToken.None);
+
+            //Assert
+            MongoTransactionSession openSession
+                = transactionSession.Should().BeOfType<MongoTransactionSession>().Subject;
+            openSession.Session.IsInTransaction.Should().BeTrue();
+        }
+    }
+
+    public class DummyPayload
+    {
+        public DummyPayload(Guid dummyValue)
+        {
+            DummyValue = dummyValue;
+        }
+
+        public Guid DummyValue { get; set; }
+    }
+}

--- a/src/Outbox.Tests/Persistence/OutboxRepositoryTests.cs
+++ b/src/Outbox.Tests/Persistence/OutboxRepositoryTests.cs
@@ -6,11 +6,11 @@ using FluentAssertions;
 using MongoDB.Driver;
 using MongoDB.Extensions.Context;
 using Squadron;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Persistence;
 using Xunit;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Tests.Persistence
+namespace MongoDB.Extensions.Outbox.Tests.Persistence
 {
     public class OutboxRepositoryTests : IClassFixture<MongoReplicaSetResource>
     {

--- a/src/Outbox/Core/ConsumerProxy.cs
+++ b/src/Outbox/Core/ConsumerProxy.cs
@@ -1,8 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
-using SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions;
+using MongoDB.Extensions.Outbox.Core.Exceptions;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class ConsumerProxy<TMessage> : IConsumerProxy<TMessage>
         where TMessage : class

--- a/src/Outbox/Core/ConsumerProxy.cs
+++ b/src/Outbox/Core/ConsumerProxy.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class ConsumerProxy<TMessage> : IConsumerProxy<TMessage>
+        where TMessage : class
+    {
+        private readonly IConsumer<TMessage> _consumer;
+
+        public ConsumerProxy(IConsumer<TMessage> consumer)
+        {
+            _consumer = consumer;
+        }
+
+        public Task ConsumeAsync(
+            object message,
+            CancellationToken token)
+        {
+            if (message is not TMessage tMessage)
+            {
+                throw new UnsupportedMessageTypeException(
+                    message.GetType().FullName!,
+                    _consumer.GetType().FullName!);
+            }
+
+            return _consumer.ConsumeAsync(tMessage, token);
+        }
+    }
+}

--- a/src/Outbox/Core/Consumption.cs
+++ b/src/Outbox/Core/Consumption.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class Consumption<TMessage> : IConsumption
+        where TMessage : class
+    {
+        private readonly TMessage _message;
+
+        public Consumption(
+            IConsumerProxy consumerProxy,
+            TMessage message)
+        {
+            ConsumerProxy = consumerProxy;
+            _message = message;
+        }
+
+        internal IConsumerProxy ConsumerProxy { get; set; }
+
+        public Task ConsumeAsync(
+            CancellationToken token)
+        {
+            return ConsumerProxy.ConsumeAsync(_message, token);
+        }
+    }
+}

--- a/src/Outbox/Core/Consumption.cs
+++ b/src/Outbox/Core/Consumption.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class Consumption<TMessage> : IConsumption
         where TMessage : class

--- a/src/Outbox/Core/ConsumptionFactory.cs
+++ b/src/Outbox/Core/ConsumptionFactory.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class ConsumptionFactory : IConsumptionFactory
     {

--- a/src/Outbox/Core/ConsumptionFactory.cs
+++ b/src/Outbox/Core/ConsumptionFactory.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class ConsumptionFactory : IConsumptionFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IReadOnlyDictionary<Type, Func<IServiceProvider, IConsumerProxy>>
+            _consumerFactories;
+
+        public ConsumptionFactory(
+            IServiceProvider serviceProvider,
+            IReadOnlyDictionary<Type, Func<IServiceProvider, IConsumerProxy>> consumerFactories)
+        {
+            _serviceProvider = serviceProvider;
+            _consumerFactories = consumerFactories;
+        }
+
+        public IConsumption Create<TMessage>(TMessage message)
+            where TMessage : class
+        {
+            IConsumerProxy proxy
+                = _consumerFactories[message.GetType()](_serviceProvider);
+
+            return new Consumption<TMessage>(proxy, message);
+        }
+    }
+}

--- a/src/Outbox/Core/Exceptions/UnsupportedMessageTypeException.cs
+++ b/src/Outbox/Core/Exceptions/UnsupportedMessageTypeException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions
+namespace MongoDB.Extensions.Outbox.Core.Exceptions
 {
     public class UnsupportedMessageTypeException: Exception
     {

--- a/src/Outbox/Core/Exceptions/UnsupportedMessageTypeException.cs
+++ b/src/Outbox/Core/Exceptions/UnsupportedMessageTypeException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core.Exceptions
+{
+    public class UnsupportedMessageTypeException: Exception
+    {
+        public UnsupportedMessageTypeException(
+            string messageTypeFullName, string consumerTypeFullName)
+            : base($"Message of Type {messageTypeFullName} " +
+                  $"is not supported by consumer {consumerTypeFullName}")
+        {
+            MessageTypeFullName = messageTypeFullName;
+            ConsumerTypeFullName = consumerTypeFullName;
+        }
+
+        public string MessageTypeFullName { get; } 
+        public string ConsumerTypeFullName { get; } 
+    }
+}

--- a/src/Outbox/Core/IConsumer.cs
+++ b/src/Outbox/Core/IConsumer.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IConsumer<TMessage>
         where TMessage: class

--- a/src/Outbox/Core/IConsumer.cs
+++ b/src/Outbox/Core/IConsumer.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IConsumer<TMessage>
+        where TMessage: class
+    {
+        Task ConsumeAsync(TMessage payload, CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/IConsumerProxy.cs
+++ b/src/Outbox/Core/IConsumerProxy.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IConsumerProxy
+    {
+        Task ConsumeAsync(object message, CancellationToken token);
+    }
+
+    public interface IConsumerProxy<TMessage>: IConsumerProxy
+    {
+    }
+}

--- a/src/Outbox/Core/IConsumerProxy.cs
+++ b/src/Outbox/Core/IConsumerProxy.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IConsumerProxy
     {

--- a/src/Outbox/Core/IConsumption.cs
+++ b/src/Outbox/Core/IConsumption.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IConsumption
     {

--- a/src/Outbox/Core/IConsumption.cs
+++ b/src/Outbox/Core/IConsumption.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IConsumption
+    {
+        Task ConsumeAsync(CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/IConsumptionFactory.cs
+++ b/src/Outbox/Core/IConsumptionFactory.cs
@@ -1,4 +1,4 @@
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IConsumptionFactory
     {

--- a/src/Outbox/Core/IConsumptionFactory.cs
+++ b/src/Outbox/Core/IConsumptionFactory.cs
@@ -1,0 +1,8 @@
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IConsumptionFactory
+    {
+        IConsumption Create<TMessage>(TMessage message)
+            where TMessage : class;
+    }
+}

--- a/src/Outbox/Core/ILockProvider.cs
+++ b/src/Outbox/Core/ILockProvider.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface ILockProvider
+    {
+        Task<bool> AcquireMessageLockAsync(
+            Guid messageId, CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/ILockProvider.cs
+++ b/src/Outbox/Core/ILockProvider.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface ILockProvider
     {

--- a/src/Outbox/Core/IMessageProcessor.cs
+++ b/src/Outbox/Core/IMessageProcessor.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IMessageProcessor
+    {
+        Task TryProcessMessageAsync(OutboxMessage message, CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/IMessageProcessor.cs
+++ b/src/Outbox/Core/IMessageProcessor.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IMessageProcessor
     {

--- a/src/Outbox/Core/IOutboxRepository.cs
+++ b/src/Outbox/Core/IOutboxRepository.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IOutboxRepository
+    {
+        Task<ITransactionSession> BeginTransactionAsync(CancellationToken token);
+
+        Task<IReadOnlyList<OutboxMessage>> GetPendingMessagesAsync(
+            CancellationToken token);
+
+        Task DeleteMessageAsync(
+            ITransactionSession session,
+            Guid messageId,
+            CancellationToken token);
+
+        Task AddMessagesAsync(
+            ITransactionSession session,
+            IReadOnlyList<OutboxMessage> messages,
+            CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/IOutboxRepository.cs
+++ b/src/Outbox/Core/IOutboxRepository.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IOutboxRepository
     {

--- a/src/Outbox/Core/IOutboxService.cs
+++ b/src/Outbox/Core/IOutboxService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface IOutboxService
+    {
+        Task AddMessagesAsync(
+            ITransactionSession session,
+            IReadOnlyList<object> payloads,
+            CancellationToken token);
+    }
+}

--- a/src/Outbox/Core/IOutboxService.cs
+++ b/src/Outbox/Core/IOutboxService.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface IOutboxService
     {

--- a/src/Outbox/Core/ISessionProvider.cs
+++ b/src/Outbox/Core/ISessionProvider.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface ISessionProvider
     {

--- a/src/Outbox/Core/ISessionProvider.cs
+++ b/src/Outbox/Core/ISessionProvider.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface ISessionProvider
+    {
+        Task<ITransactionSession> BeginTransactionAsync(
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Outbox/Core/ITransactionSession.cs
+++ b/src/Outbox/Core/ITransactionSession.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public interface ITransactionSession : IDisposable
     {

--- a/src/Outbox/Core/ITransactionSession.cs
+++ b/src/Outbox/Core/ITransactionSession.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public interface ITransactionSession : IDisposable
+    {
+        Task CommitAsync();
+    }
+}

--- a/src/Outbox/Core/MessageProcessor.cs
+++ b/src/Outbox/Core/MessageProcessor.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    internal class MessageProcessor: IMessageProcessor
+    {
+        private readonly OutboxOptions _outboxOptions;
+        private readonly ILockProvider _lockProvider;
+        private readonly IConsumptionFactory _consumptionFactory;
+        private readonly IOutboxRepository _outboxRepository;
+        private readonly ILogger<MessagesDeliveryService> _logger;
+
+        public MessageProcessor(
+            OutboxOptions outboxOptions,
+            ILockProvider lockProvider,
+            IConsumptionFactory consumptionFactory,
+            IOutboxRepository outboxRepository,
+            ILogger<MessagesDeliveryService> logger)
+        {
+            _outboxOptions = outboxOptions;
+            _lockProvider = lockProvider;
+            _consumptionFactory = consumptionFactory;
+            _outboxRepository = outboxRepository;
+            _logger = logger;
+        }
+
+        public async Task TryProcessMessageAsync(OutboxMessage message, CancellationToken token)
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            source.CancelAfter(_outboxOptions.Message.LockDuration);
+
+            bool acquiredLock
+                = await _lockProvider.AcquireMessageLockAsync(
+                    message.Id, source.Token);
+
+            if (!acquiredLock)
+            {
+                return;
+            }
+
+            await ConsumeMessage(message, source.Token);
+
+            token.ThrowIfCancellationRequested();
+        }
+
+        private async Task ConsumeMessage(
+            OutboxMessage message, CancellationToken token)
+        {
+            ITransactionSession session
+                = await _outboxRepository.BeginTransactionAsync(token);
+
+            try
+            {
+                IConsumption consumption
+                    = _consumptionFactory.Create(message.Payload);
+
+                await consumption.ConsumeAsync(token);
+
+                await _outboxRepository.DeleteMessageAsync(
+                    session, message.Id, token);
+                await session.CommitAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Process Message Failed.", ex);
+                throw;
+            }
+            finally
+            {
+                session.Dispose();
+            }
+        }
+    }
+}

--- a/src/Outbox/Core/MessageProcessor.cs
+++ b/src/Outbox/Core/MessageProcessor.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     internal class MessageProcessor: IMessageProcessor
     {

--- a/src/Outbox/Core/MessagesDeliveryService.cs
+++ b/src/Outbox/Core/MessagesDeliveryService.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    internal class MessagesDeliveryService : BackgroundService
+    {
+        private readonly IOutboxRepository _outboxRepository;
+        private readonly OutboxOptions _outboxOptions;
+        private readonly ILogger<MessagesDeliveryService> _logger;
+        private readonly IMessageProcessor _messageProcessor;
+
+        public MessagesDeliveryService(
+            IOutboxRepository outboxRepository,
+            OutboxOptions outboxOptions,
+            ILogger<MessagesDeliveryService> logger,
+            IMessageProcessor messageProcessor)
+        {
+            _outboxRepository = outboxRepository;
+            _outboxOptions = outboxOptions;
+            _logger = logger;
+            _messageProcessor = messageProcessor;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await Task.Yield();
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                Activity? activity = default;
+                try
+                {
+                    await Task.Delay(
+                        _outboxOptions.FallbackWorker.InboxReadInterval, stoppingToken);
+
+                    await ProcessPendingMessages(stoppingToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogError(
+                        $"Restart Process Pending Messages", ex);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        $"Error while reading tracking entry message", ex);
+                }
+                finally
+                {
+                    activity?.Dispose();
+                }
+            }
+        }
+
+        protected virtual async Task ProcessPendingMessages(CancellationToken token)
+        {
+            IReadOnlyList<OutboxMessage> messages
+                    = await _outboxRepository.GetPendingMessagesAsync(token);
+
+            List<Task> pendingMessages = new List<Task>();
+
+            foreach(OutboxMessage message in messages)
+            {
+                pendingMessages.Add(
+                    _messageProcessor.TryProcessMessageAsync(message, token));
+            }
+
+            await Task.WhenAll(pendingMessages);
+        }
+    }
+}

--- a/src/Outbox/Core/MessagesDeliveryService.cs
+++ b/src/Outbox/Core/MessagesDeliveryService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     internal class MessagesDeliveryService : BackgroundService
     {

--- a/src/Outbox/Core/OutboxMessage.cs
+++ b/src/Outbox/Core/OutboxMessage.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class OutboxMessage
     {

--- a/src/Outbox/Core/OutboxMessage.cs
+++ b/src/Outbox/Core/OutboxMessage.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class OutboxMessage
+    {
+        public OutboxMessage(
+            Guid id, object payload, DateTime creationDate)
+        {
+            Id = id;
+            Payload = payload;
+            CreationDate = creationDate;
+        }
+
+        public Guid Id { get; set; }
+        public object Payload { get; set; }
+        public DateTime CreationDate { get; set; }
+    }
+}

--- a/src/Outbox/Core/OutboxOptions.cs
+++ b/src/Outbox/Core/OutboxOptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class OutboxOptions
     {

--- a/src/Outbox/Core/OutboxOptions.cs
+++ b/src/Outbox/Core/OutboxOptions.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class OutboxOptions
+    {
+        public OutboxFallBackWorkerOptions FallbackWorker { get; set; }
+
+        public MessageOptions Message { get; set; }
+    }
+
+    public class OutboxOptions<TPersistenceOptions>: OutboxOptions
+        where TPersistenceOptions : class
+    {
+        public TPersistenceOptions Persistence { get; set; }
+    }
+
+    public class OutboxFallBackWorkerOptions
+    {
+        public TimeSpan MessageMinimumAge { get; set; }
+        public TimeSpan InboxReadInterval { get; set; }
+    }
+
+    public class MessageOptions
+    {
+        public TimeSpan LockDuration { get; set; }
+    }
+}

--- a/src/Outbox/Core/OutboxService.cs
+++ b/src/Outbox/Core/OutboxService.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core
+namespace MongoDB.Extensions.Outbox.Core
 {
     public class OutboxService : IOutboxService
     {

--- a/src/Outbox/Core/OutboxService.cs
+++ b/src/Outbox/Core/OutboxService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core
+{
+    public class OutboxService : IOutboxService
+    {
+        private readonly IOutboxRepository _outboxRepository;
+
+        public OutboxService(
+            IOutboxRepository outboxRepository)
+        {
+            _outboxRepository = outboxRepository;
+        }
+
+        public Task AddMessagesAsync(
+            ITransactionSession session,
+            IReadOnlyList<object> payloads,
+            CancellationToken token)
+        {
+            IReadOnlyList<OutboxMessage> messages = payloads
+                .Select(p => new OutboxMessage(
+                    id: Guid.NewGuid(),
+                    payload: p,
+                    creationDate: DateTime.UtcNow))
+                .ToArray();
+
+            return _outboxRepository.AddMessagesAsync(session, messages, token);
+        }
+    }
+}

--- a/src/Outbox/Core/Pipeline/OutboxBuilder.cs
+++ b/src/Outbox/Core/Pipeline/OutboxBuilder.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+{
+    public class OutboxBuilder
+    {
+        private readonly OutboxBuildingPlan _buildPlan;
+
+        protected OutboxBuilder(OutboxBuildingPlan buildPlan)
+        {
+            _buildPlan = buildPlan;
+        }
+
+        public IServiceCollection Services => _buildPlan.Services;
+
+        internal OutboxBuilder(IServiceCollection services)
+        {
+            _buildPlan = new OutboxBuildingPlan(services);
+        }
+
+        public OutboxBuilder AddConsumer<TConsumer, TMessage>()
+            where TConsumer : class, IConsumer<TMessage>
+            where TMessage : class
+        {
+            _buildPlan.Services.AddTransient<IConsumer<TMessage>, TConsumer>();
+            _buildPlan.Services.AddTransient<
+                IConsumerProxy<TMessage>, ConsumerProxy<TMessage>>();
+
+            _buildPlan.ConsumerBuilders.Add(
+                new OutboxConsumerBuilder(
+                    _buildPlan,
+                    consumerType: typeof(IConsumerProxy<TMessage>),
+                    messageType: typeof(TMessage)));
+
+            return this;
+        }
+    }
+}

--- a/src/Outbox/Core/Pipeline/OutboxBuilder.cs
+++ b/src/Outbox/Core/Pipeline/OutboxBuilder.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+namespace MongoDB.Extensions.Outbox.Core.Pipeline
 {
     public class OutboxBuilder
     {

--- a/src/Outbox/Core/Pipeline/OutboxBuildingPlan.cs
+++ b/src/Outbox/Core/Pipeline/OutboxBuildingPlan.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+{
+    public class OutboxBuildingPlan
+    {
+        public OutboxBuildingPlan(IServiceCollection services)
+        {
+            Services = services;
+            ConsumerBuilders = new List<OutboxConsumerBuilder>();
+
+            services.AddSingleton<IConsumptionFactory>(p =>
+            {
+                var factories = ConsumerBuilders
+                    .ToDictionary(
+                        b => b.MessageType,
+                        b => GetConsumerProxyFactory(b.ConsumerType));
+
+                return new ConsumptionFactory(p, factories);
+            });
+        }
+
+        public IServiceCollection Services { get; }
+        internal List<OutboxConsumerBuilder> ConsumerBuilders { get; }
+
+        private static Func<IServiceProvider, IConsumerProxy> GetConsumerProxyFactory(
+            Type consumerProxyType)
+        {
+            return p => GetConsumerProxy(p, consumerProxyType);
+        }
+
+        private static IConsumerProxy GetConsumerProxy(
+            IServiceProvider p,
+            Type consumerProxyType)
+        {
+            IConsumerProxy proxy
+                = (IConsumerProxy)p.GetRequiredService(consumerProxyType);
+
+            return proxy;
+        }
+    }
+}

--- a/src/Outbox/Core/Pipeline/OutboxBuildingPlan.cs
+++ b/src/Outbox/Core/Pipeline/OutboxBuildingPlan.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+namespace MongoDB.Extensions.Outbox.Core.Pipeline
 {
     public class OutboxBuildingPlan
     {

--- a/src/Outbox/Core/Pipeline/OutboxConsumerBuilder.cs
+++ b/src/Outbox/Core/Pipeline/OutboxConsumerBuilder.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+{
+    public class OutboxConsumerBuilder: OutboxBuilder
+    {
+        internal OutboxConsumerBuilder(
+            OutboxBuildingPlan buildPlan,
+            Type consumerType,
+            Type messageType)
+            : base(buildPlan)
+        {
+            ConsumerType = consumerType;
+            MessageType = messageType;
+        }
+
+        public Type ConsumerType { get; }
+        public Type MessageType { get; }
+    }
+}

--- a/src/Outbox/Core/Pipeline/OutboxConsumerBuilder.cs
+++ b/src/Outbox/Core/Pipeline/OutboxConsumerBuilder.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline
+namespace MongoDB.Extensions.Outbox.Core.Pipeline
 {
     public class OutboxConsumerBuilder: OutboxBuilder
     {

--- a/src/Outbox/Core/ServiceCollectionExtensions.cs
+++ b/src/Outbox/Core/ServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core.Pipeline;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Outbox/Core/ServiceCollectionExtensions.cs
+++ b/src/Outbox/Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class OutboxServiceCollectionExtensions
+    {
+        public static OutboxBuilder AddTransactionalOutbox(
+            this IServiceCollection services,
+            OutboxOptions options)
+        {
+            services
+                .AddSingleton(options)
+                .AddSingleton<IOutboxService, OutboxService>()
+                .AddSingleton<IMessageProcessor, MessageProcessor>()
+                .AddHostedService<MessagesDeliveryService>();
+
+            var builder = new OutboxBuilder(services);
+
+            return builder;
+        }
+    }
+}

--- a/src/Outbox/InternalsVisibleTo.cs
+++ b/src/Outbox/InternalsVisibleTo.cs
@@ -1,3 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("SwissLife.MongoDB.Extensions.Outbox.Tests")]
+[assembly: InternalsVisibleTo("MongoDB.Extensions.Outbox.Tests")]

--- a/src/Outbox/InternalsVisibleTo.cs
+++ b/src/Outbox/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SwissLife.MongoDB.Extensions.Outbox.Tests")]

--- a/src/Outbox/Outbox.csproj
+++ b/src/Outbox/Outbox.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCResourceProjectProps)" Condition="Exists('$(CCResourceProjectProps)')" />
+  
+  <PropertyGroup>
+    <AssemblyName>MongoDB.Extensions.Outbox</AssemblyName>
+    <RootNamespace>MongoDB.Extensions.Outbox</RootNamespace>
+    <PackageId>MongoDB.Extensions.Outbox</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Context\Context.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Outbox/OutboxServiceCollectionExtensions.cs
+++ b/src/Outbox/OutboxServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 using MongoDB.Extensions.Context;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline;
-using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core.Pipeline;
+using MongoDB.Extensions.Outbox.Persistence;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Outbox/OutboxServiceCollectionExtensions.cs
+++ b/src/Outbox/OutboxServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using MongoDB.Extensions.Context;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Core.Pipeline;
+using SwissLife.MongoDB.Extensions.Outbox.Persistence;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static partial class OutboxServiceCollectionExtensions
+    {
+        public static OutboxBuilder AddMongoTransactionalOutbox(
+            this IServiceCollection services,
+            OutboxOptions<DatabaseOptions> options)
+        {
+            OutboxBuilder builder = services.AddTransactionalOutbox(options);
+
+            services
+                .AddSingleton(options)
+                .AddSingleton<ILockProvider, MongoDBLockProvider> ()
+                .AddSingleton<IOutboxDbContext, OutboxDbContext>(
+                    ctx =>
+                    {
+                        MongoOptions mongoOptions =
+                            new MongoOptions
+                            {
+                                ConnectionString = options.Persistence.ConnectionString,
+                                DatabaseName = options.Persistence.DatabaseName
+                            };
+
+                        var context = new OutboxDbContext(mongoOptions, options.Message);
+                        context.Initialize();
+
+                        return context;
+                    })
+                .AddSingleton<IOutboxRepository, OutboxRepository>()
+                .AddSingleton<ISessionProvider, MongoSessionProvider>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Outbox/Persistence/DatabaseOptions.cs
+++ b/src/Outbox/Persistence/DatabaseOptions.cs
@@ -1,0 +1,14 @@
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class DatabaseOptions
+    {
+        public DatabaseOptions(string connectionString, string databaseName)
+        {
+            ConnectionString = connectionString;
+            DatabaseName = databaseName;
+        }
+
+        public string ConnectionString { get; }
+        public string DatabaseName { get; }
+    }
+}

--- a/src/Outbox/Persistence/DatabaseOptions.cs
+++ b/src/Outbox/Persistence/DatabaseOptions.cs
@@ -1,4 +1,4 @@
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class DatabaseOptions
     {

--- a/src/Outbox/Persistence/IOutboxDbContext.cs
+++ b/src/Outbox/Persistence/IOutboxDbContext.cs
@@ -1,6 +1,6 @@
 using MongoDB.Extensions.Context;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public interface IOutboxDbContext: IMongoDbContext
     {

--- a/src/Outbox/Persistence/IOutboxDbContext.cs
+++ b/src/Outbox/Persistence/IOutboxDbContext.cs
@@ -1,0 +1,8 @@
+using MongoDB.Extensions.Context;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public interface IOutboxDbContext: IMongoDbContext
+    {
+    }
+}

--- a/src/Outbox/Persistence/MessageLock.cs
+++ b/src/Outbox/Persistence/MessageLock.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class MessageLock
+    {
+        public MessageLock(Guid id, DateTime lockedAt)
+        {
+            Id = id;
+            LockedAt = lockedAt;
+        }
+
+        public Guid Id { get; set; }
+        public DateTime LockedAt { get; set; }
+    }
+}

--- a/src/Outbox/Persistence/MessageLock.cs
+++ b/src/Outbox/Persistence/MessageLock.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class MessageLock
     {

--- a/src/Outbox/Persistence/MessageLockConfiguration.cs
+++ b/src/Outbox/Persistence/MessageLockConfiguration.cs
@@ -1,0 +1,53 @@
+using System;
+using MongoDB.Driver;
+using MongoDB.Extensions.Context;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class MessageLockConfiguration
+        : IMongoCollectionConfiguration<MessageLock>
+    {
+        private readonly TimeSpan _lockTimeToLive;
+
+        public MessageLockConfiguration(TimeSpan lockTimeToLive)
+        {
+            _lockTimeToLive = lockTimeToLive;
+        }
+
+        public void OnConfiguring(
+            IMongoCollectionBuilder<MessageLock> mongoCollectionBuilder)
+        {
+            mongoCollectionBuilder
+                .WithCollectionName("outbox.locks")
+                .AddBsonClassMap<MessageLock>(
+                cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                    cm.MapIdField(c => c.Id);
+                })
+                .WithCollectionConfiguration(setting =>
+                {
+                    setting
+                        .WithReadPreference(ReadPreference.Primary)
+                        .WithReadConcern(ReadConcern.Majority)
+                        .WithWriteConcern(WriteConcern.WMajority);
+
+                    CreateIndexes(setting.Indexes);
+                });
+        }
+
+        private void CreateIndexes(
+                IMongoIndexManager<MessageLock> indexes)
+        {
+            IndexKeysDefinition<MessageLock> indexDefinition
+                = Builders<MessageLock>.IndexKeys.Ascending(nameof(MessageLock.LockedAt));
+
+            var indexOptions = new CreateIndexOptions { ExpireAfter = _lockTimeToLive };
+
+            var indexModel = new CreateIndexModel<MessageLock>(indexDefinition, indexOptions);
+
+            indexes.CreateOne(indexModel);
+        }
+    }
+}

--- a/src/Outbox/Persistence/MessageLockConfiguration.cs
+++ b/src/Outbox/Persistence/MessageLockConfiguration.cs
@@ -2,7 +2,7 @@ using System;
 using MongoDB.Driver;
 using MongoDB.Extensions.Context;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class MessageLockConfiguration
         : IMongoCollectionConfiguration<MessageLock>

--- a/src/Outbox/Persistence/MongoDBLockProvider.cs
+++ b/src/Outbox/Persistence/MongoDBLockProvider.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class MongoDBLockProvider : ILockProvider
     {

--- a/src/Outbox/Persistence/MongoDBLockProvider.cs
+++ b/src/Outbox/Persistence/MongoDBLockProvider.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class MongoDBLockProvider : ILockProvider
+    {
+        private readonly IMongoCollection<MessageLock> _messagesLocks;
+
+        public MongoDBLockProvider(
+            IOutboxDbContext dbContext)
+        {
+            _messagesLocks = dbContext.CreateCollection<MessageLock>();
+        }
+
+        public async Task<bool> AcquireMessageLockAsync(
+            Guid messageId, CancellationToken token)
+        {
+            FilterDefinition<MessageLock> filter
+                = Builders<MessageLock>.Filter.Eq(l => l.Id, messageId);
+
+            UpdateDefinition<MessageLock> setOnInsert =
+            Builders<MessageLock>.Update.SetOnInsert(
+                    item => item.LockedAt, DateTime.UtcNow);
+
+            UpdateResult operationResult = await _messagesLocks
+                .UpdateOneAsync(
+                    filter,
+                    setOnInsert,
+                    options: new UpdateOptions
+                    {
+                        IsUpsert = true,
+                    },
+                    cancellationToken: token);
+
+            if (operationResult.IsAcknowledged
+                && operationResult.UpsertedId != null)
+            {
+                // we got the lock
+                return true;
+            }
+
+            //we didn't get the lock
+            return false;
+        }
+    }
+}

--- a/src/Outbox/Persistence/MongoSessionProvider.cs
+++ b/src/Outbox/Persistence/MongoSessionProvider.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class MongoSessionProvider : ISessionProvider
     {

--- a/src/Outbox/Persistence/MongoSessionProvider.cs
+++ b/src/Outbox/Persistence/MongoSessionProvider.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class MongoSessionProvider : ISessionProvider
+    {
+        private readonly IMongoClient _mongoClient;
+
+        public MongoSessionProvider(IOutboxDbContext dbContext)
+        {
+            _mongoClient = dbContext.Client;
+        }
+
+        public Task<ITransactionSession> BeginTransactionAsync(
+            CancellationToken cancellationToken)
+        {
+            return BeginTransactionAsync(true, cancellationToken);
+        }
+
+        private async Task<ITransactionSession> BeginTransactionAsync(
+            bool safeModeEnabled,
+            CancellationToken cancellationToken)
+        {
+            IClientSessionHandle clientSession = await _mongoClient
+                .StartSessionAsync(cancellationToken: cancellationToken);
+
+            var transactionOptions = new TransactionOptions(
+                ReadConcern.Majority,
+                ReadPreference.Primary,
+                WriteConcern.WMajority.With(journal: safeModeEnabled),
+                TimeSpan.FromSeconds(180));
+
+            clientSession.StartTransaction(transactionOptions);
+
+            return new MongoTransactionSession(clientSession, cancellationToken);
+        }
+    }
+}

--- a/src/Outbox/Persistence/MongoTransactionSession.cs
+++ b/src/Outbox/Persistence/MongoTransactionSession.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class MongoTransactionSession : ITransactionSession
     {

--- a/src/Outbox/Persistence/MongoTransactionSession.cs
+++ b/src/Outbox/Persistence/MongoTransactionSession.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class MongoTransactionSession : ITransactionSession
+    {
+        private readonly CancellationToken _cancellationToken;
+        private bool _disposed;
+
+        public MongoTransactionSession(
+            IClientSessionHandle clientSession,
+            CancellationToken cancellationToken)
+        {
+            Session = clientSession;
+            _cancellationToken = cancellationToken;
+        }
+
+        public IClientSessionHandle Session { get; }
+
+        public async Task CommitAsync()
+        {
+            await Session.CommitTransactionAsync(_cancellationToken);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    Session.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Outbox/Persistence/OutboxDbContext.cs
+++ b/src/Outbox/Persistence/OutboxDbContext.cs
@@ -1,0 +1,26 @@
+using MongoDB.Extensions.Context;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class OutboxDbContext : MongoDbContext, IOutboxDbContext
+    {
+        private readonly MessageOptions _messageOptions;
+
+        public OutboxDbContext(
+            MongoOptions mongoOptions,
+            MessageOptions messageOptions)
+            : base(mongoOptions, enableAutoInitialize: false)
+        {
+            _messageOptions = messageOptions;
+        }
+
+        protected override void OnConfiguring(
+            IMongoDatabaseBuilder mongoDatabaseBuilder)
+        {
+            mongoDatabaseBuilder
+                .ConfigureCollection(new OutboxMessageConfiguration())
+                .ConfigureCollection(new MessageLockConfiguration(_messageOptions.LockDuration));
+        }
+    }
+}

--- a/src/Outbox/Persistence/OutboxDbContext.cs
+++ b/src/Outbox/Persistence/OutboxDbContext.cs
@@ -1,7 +1,7 @@
 using MongoDB.Extensions.Context;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class OutboxDbContext : MongoDbContext, IOutboxDbContext
     {
@@ -20,7 +20,8 @@ namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
         {
             mongoDatabaseBuilder
                 .ConfigureCollection(new OutboxMessageConfiguration())
-                .ConfigureCollection(new MessageLockConfiguration(_messageOptions.LockDuration));
+                .ConfigureCollection(new MessageLockConfiguration(_messageOptions.LockDuration))
+                .AddAllowedTypes("MongoDB.Extensions.Outbox");
         }
     }
 }

--- a/src/Outbox/Persistence/OutboxMessageConfiguration.cs
+++ b/src/Outbox/Persistence/OutboxMessageConfiguration.cs
@@ -1,9 +1,9 @@
 using MongoDB.Driver;
 using MongoDB.Extensions.Context;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
-using SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization;
+using MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Persistence.Serialization;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class OutboxMessageConfiguration
         : IMongoCollectionConfiguration<OutboxMessage>

--- a/src/Outbox/Persistence/OutboxMessageConfiguration.cs
+++ b/src/Outbox/Persistence/OutboxMessageConfiguration.cs
@@ -1,0 +1,47 @@
+using MongoDB.Driver;
+using MongoDB.Extensions.Context;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+using SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class OutboxMessageConfiguration
+        : IMongoCollectionConfiguration<OutboxMessage>
+    {
+        public void OnConfiguring(
+            IMongoCollectionBuilder<OutboxMessage> mongoCollectionBuilder)
+        {
+            mongoCollectionBuilder
+                .WithCollectionName("outbox.messages")
+                .AddBsonClassMap<OutboxMessage>(
+                cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                    cm.MapIdField(c => c.Id);
+                    cm.MapProperty(y => y.Payload)
+                        .SetSerializer(new DataObjectSerializer());
+                })
+                .WithCollectionConfiguration(settings =>
+                {
+                    settings
+                        .WithReadPreference(ReadPreference.Nearest)
+                        .WithReadConcern(ReadConcern.Majority)
+                        .WithWriteConcern(WriteConcern.WMajority); //TODO: WithJournal?
+
+                    CreateIndexes(settings.Indexes);
+                });
+        }
+
+        private void CreateIndexes(
+                IMongoIndexManager<OutboxMessage> indexes)
+        {
+            IndexKeysDefinition<OutboxMessage> indexDefinition
+                = Builders<OutboxMessage>.IndexKeys.Descending(nameof(OutboxMessage.CreationDate));
+
+            var indexModel = new CreateIndexModel<OutboxMessage>(indexDefinition);
+
+            indexes.CreateOne(indexModel);
+        }
+    }
+}

--- a/src/Outbox/Persistence/OutboxRepository.cs
+++ b/src/Outbox/Persistence/OutboxRepository.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Driver;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public class OutboxRepository : IOutboxRepository
     {

--- a/src/Outbox/Persistence/OutboxRepository.cs
+++ b/src/Outbox/Persistence/OutboxRepository.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public class OutboxRepository : IOutboxRepository
+    {
+        private readonly OutboxOptions _options;
+        private readonly IMongoCollection<OutboxMessage> _messages;
+        private readonly ISessionProvider _sessionProvider;
+
+        public OutboxRepository(
+            OutboxOptions options,
+            IOutboxDbContext dbContext,
+            ISessionProvider sessionProvider)
+        {
+            _options = options;
+            _messages = dbContext.CreateCollection<OutboxMessage>();
+            _sessionProvider = sessionProvider;
+        }
+
+        public async Task<IReadOnlyList<OutboxMessage>> GetPendingMessagesAsync(
+            CancellationToken token)
+        {
+            DateTime maxCreationDate = DateTime.UtcNow.Add(
+                -_options.FallbackWorker.MessageMinimumAge);
+
+            FilterDefinition<OutboxMessage> filter = Builders<OutboxMessage>.Filter
+                .Lt(m => m.CreationDate, maxCreationDate);
+
+            IReadOnlyList<OutboxMessage> results
+                = await _messages.Find(filter).ToListAsync(token);
+
+            return results;
+        }
+
+        public Task<ITransactionSession> BeginTransactionAsync(CancellationToken token)
+        {
+            return _sessionProvider.BeginTransactionAsync(token);
+        }
+
+        public async Task DeleteMessageAsync(
+            ITransactionSession session,
+            Guid messageId,
+            CancellationToken token)
+        {
+            await _messages
+                .DeleteOneAsync(
+                    session.GetSessionHandle(),
+                    Builders<OutboxMessage>.Filter.Eq(l => l.Id, messageId),
+                    cancellationToken: token);
+        }
+
+        public async Task AddMessagesAsync(
+            ITransactionSession session,
+            IReadOnlyList<OutboxMessage> messages,
+            CancellationToken token)
+        {
+            await _messages.InsertManyAsync(
+                session.GetSessionHandle(),
+                messages,
+                cancellationToken: token);
+        }
+    }
+}

--- a/src/Outbox/Persistence/Serialization/AssemblyQualifiedDiscriminatorConvention.cs
+++ b/src/Outbox/Persistence/Serialization/AssemblyQualifiedDiscriminatorConvention.cs
@@ -1,0 +1,40 @@
+using MongoDB.Bson.Serialization.Conventions;
+using System;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using System.Text.Json.Nodes;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization
+{
+    public class AssemblyQualifiedDiscriminatorConvention : IDiscriminatorConvention
+    {
+        public string ElementName
+        {
+            get
+            {
+                return "_t";
+            }
+        }
+
+        public Type GetActualType(IBsonReader bsonReader, Type nominalType)
+        {
+            BsonReaderBookmark bookmark = bsonReader.GetBookmark();
+            bsonReader.ReadStartDocument();
+            string typeValue = string.Empty;
+            if (bsonReader.FindElement(ElementName))
+                typeValue = bsonReader.ReadString();
+            else
+                throw new NotSupportedException();
+
+            bsonReader.ReturnToBookmark(bookmark);
+            var result = Type.GetType(typeValue);
+            return result;
+        }
+
+        public BsonValue GetDiscriminator(Type nominalType, Type actualType)
+        {
+            return actualType.AssemblyQualifiedName;
+        }
+    }
+}

--- a/src/Outbox/Persistence/Serialization/AssemblyQualifiedDiscriminatorConvention.cs
+++ b/src/Outbox/Persistence/Serialization/AssemblyQualifiedDiscriminatorConvention.cs
@@ -1,11 +1,9 @@
 using MongoDB.Bson.Serialization.Conventions;
 using System;
-using System.Linq;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
-using System.Text.Json.Nodes;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization
+namespace MongoDB.Extensions.Outbox.Persistence.Serialization
 {
     public class AssemblyQualifiedDiscriminatorConvention : IDiscriminatorConvention
     {

--- a/src/Outbox/Persistence/Serialization/DataObjectSerializer.cs
+++ b/src/Outbox/Persistence/Serialization/DataObjectSerializer.cs
@@ -1,0 +1,167 @@
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization
+{
+    /// <summary>
+    /// From https://github.com/danielgerlag/workflow-core/
+    /// Thanks @Daniel Gerlag
+    /// </summary>
+    public class DataObjectSerializer : SerializerBase<object>
+    {
+        private static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Objects,
+        };
+
+        public override object Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            if (context.Reader.CurrentBsonType == BsonType.String)
+            {
+                var raw = BsonSerializer.Deserialize<string>(context.Reader);
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<object>(raw, SerializerSettings);
+            }
+
+            object? obj = BsonSerializer.Deserialize(context.Reader, typeof(object));
+            return obj;
+        }
+
+        public override void Serialize(
+            BsonSerializationContext context,
+            BsonSerializationArgs args,
+            object value)
+        {
+            BsonDocument doc;
+            if (BsonClassMap.IsClassMapRegistered(value.GetType()))
+            {
+                doc = value.ToBsonDocument();
+                doc.Remove("_t");
+                doc.InsertAt(0, new BsonElement("_t", value.GetType().AssemblyQualifiedName));
+                AddTypeInformation(doc.Elements, value, string.Empty);
+            }
+            else
+            {
+                var str = Newtonsoft.Json.JsonConvert.SerializeObject(value, SerializerSettings);
+                doc = BsonDocument.Parse(str);
+                ConvertMetaFormat(doc);
+            }
+
+            BsonSerializer.Serialize(context.Writer, doc);
+        }
+
+        private void AddTypeInformation(IEnumerable<BsonElement> elements, object value, string xPath)
+        {
+            foreach (BsonElement element in elements)
+            {
+                var elementXPath = string.IsNullOrEmpty(xPath) ? element.Name : xPath + "." + element.Name;
+                if (element.Value.IsBsonDocument)
+                {
+                    BsonDocument doc = element.Value.AsBsonDocument;
+                    doc.Remove("_t");
+                    doc.InsertAt(0, new BsonElement("_t", GetTypeNameFromXPath(value, elementXPath)));
+                    AddTypeInformation(doc.Elements, value, elementXPath);
+                }
+                if (element.Value.IsBsonArray)
+                {
+                    AddTypeInformation(element.Value.AsBsonArray, value, elementXPath);
+                }
+            }
+        }
+
+        private string GetTypeNameFromXPath(object root, string xPath)
+        {
+            var parts = xPath.Split('.').ToList();
+            var value = root;
+            while (parts.Count > 0)
+            {
+                var subPath = parts[0];
+                if (subPath[0] == '[')
+                {
+                    var index = int.Parse(subPath.Trim('[', ']'));
+                    if (value is IList || value.GetType().IsArray)
+                    {
+                        var list = (IList)value;
+                        value = list[index];
+                    }
+                    else
+                    {
+                        throw new NotSupportedException();
+                    }
+                }
+                else
+                {
+                    System.Reflection.PropertyInfo? propInfo
+                        = value.GetType().GetProperty(subPath);
+                    value = propInfo.GetValue(value);
+                }
+
+                parts.RemoveAt(0);
+            }
+
+            return value.GetType().AssemblyQualifiedName;
+        }
+
+        private void AddTypeInformation(IEnumerable<BsonValue> elements, object value, string xPath)
+        {
+            //foreach (var element in elements) 
+            for (var i = 0; i < elements.Count(); i++)
+            {
+                BsonValue element = elements.ElementAt(i);
+                if (element.IsBsonDocument)
+                {
+                    BsonDocument doc = element.AsBsonDocument;
+                    var elementXPath = xPath + $".[{i}]";
+                    doc.Remove("_t");
+                    doc.InsertAt(0, new BsonElement("_t", GetTypeNameFromXPath(value, elementXPath)));
+                    AddTypeInformation(doc.Elements, value, elementXPath);
+                }
+
+                if (element.IsBsonArray)
+                {
+                    AddTypeInformation(element.AsBsonArray, value, xPath);
+                }
+            }
+        }
+
+        private static void ConvertMetaFormat(BsonDocument root)
+        {
+            var stack = new Stack<BsonDocument>();
+            stack.Push(root);
+
+            while (stack.Count > 0)
+            {
+                BsonDocument doc = stack.Pop();
+
+                if (doc.TryGetElement("$type", out BsonElement typeElem))
+                {
+                    doc.RemoveElement(typeElem);
+
+                    if (doc.Elements.All(x => x.Name != "_t"))
+                        doc.InsertAt(0, new BsonElement("_t", typeElem.Value));
+                }
+
+                foreach (BsonElement subDoc in doc.Elements)
+                {
+                    if (subDoc.Value.IsBsonDocument)
+                        stack.Push(subDoc.Value.ToBsonDocument());
+
+                    if (subDoc.Value.IsBsonArray)
+                    {
+                        foreach (BsonValue? element in subDoc.Value.AsBsonArray)
+                        {
+                            if (element.IsBsonDocument)
+                                stack.Push(element.ToBsonDocument());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Outbox/Persistence/Serialization/DataObjectSerializer.cs
+++ b/src/Outbox/Persistence/Serialization/DataObjectSerializer.cs
@@ -6,9 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization
+namespace MongoDB.Extensions.Outbox.Persistence.Serialization
 {
     /// <summary>
     /// From https://github.com/danielgerlag/workflow-core/
@@ -110,7 +110,7 @@ namespace SwissLife.MongoDB.Extensions.Outbox.Persistence.Serialization
 
         private void AddTypeInformation(IEnumerable<BsonValue> elements, object value, string xPath)
         {
-            //foreach (var element in elements) 
+            //foreach (var element in elements)
             for (var i = 0; i < elements.Count(); i++)
             {
                 BsonValue element = elements.ElementAt(i);

--- a/src/Outbox/Persistence/TransactionSessionExtensions.cs
+++ b/src/Outbox/Persistence/TransactionSessionExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using MongoDB.Driver;
-using SwissLife.MongoDB.Extensions.Outbox.Core;
+using MongoDB.Extensions.Outbox.Core;
 
-namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+namespace MongoDB.Extensions.Outbox.Persistence
 {
     public static class TransactionSessionExtensions
     {

--- a/src/Outbox/Persistence/TransactionSessionExtensions.cs
+++ b/src/Outbox/Persistence/TransactionSessionExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using MongoDB.Driver;
+using SwissLife.MongoDB.Extensions.Outbox.Core;
+
+namespace SwissLife.MongoDB.Extensions.Outbox.Persistence
+{
+    public static class TransactionSessionExtensions
+    {
+        public static IClientSessionHandle GetSessionHandle(
+            this ITransactionSession session)
+        {
+            if (session is MongoTransactionSession mongoTransactionSession)
+            {
+                return mongoTransactionSession.Session;
+            }
+
+            throw new InvalidOperationException(
+                $"Unknown session type {session.GetType().Name}");
+        }
+    }
+}


### PR DESCRIPTION
Adds a new Package that supports the Outbox Pattern.

- Messages to consume get saved in a new collection `outbox.messages`
- Handling the initial transaction that saves the message is the responsibility of the user of the package
- The messages get consumed only once. A distributed semaphore is managed through special read/write preferences in MongoDb so that a message can get locked by one consuming application for a specified time (30 seconds by default). If the consuming application does not delete the message within that time, the message becomes available again for consumption. 
- Messages get consumed right away: consumers get triggered via ThreadChannel to consume new messages asap. If the consumers fail for some reason, then a background job (named Fallback job) will get the message eventually and consume it. 

