### PR TITLE
Extended ObjectSerializer uses registered GuidSerializer.GuidRepresentation

### DIFF
--- a/src/Context.AllowedTypes.Tests/Helpers/TestHelpers.cs
+++ b/src/Context.AllowedTypes.Tests/Helpers/TestHelpers.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using MongoDB.Extensions.Context.Internal;
 
 namespace MongoDB.Extensions.Context.AllowedTypes.Tests.Helpers;
 

--- a/src/Context.AllowedTypes.Tests/MongoDatabaseBuilderTests.cs
+++ b/src/Context.AllowedTypes.Tests/MongoDatabaseBuilderTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Extensions.Context.AllowedTypes.Tests.Helpers;
-using MongoDB.Extensions.Context.Internal;
 using Snapshooter.Xunit;
 using Squadron;
 using Xunit;

--- a/src/Context.AllowedTypes.Tests/TypeObjectSerializerTests.cs
+++ b/src/Context.AllowedTypes.Tests/TypeObjectSerializerTests.cs
@@ -1,5 +1,4 @@
 using MongoDB.Extensions.Context.AllowedTypes.Tests.Helpers;
-using MongoDB.Extensions.Context.Internal;
 using Snapshooter.Xunit;
 using Xunit;
 

--- a/src/Context.GuidSerializer.Tests/Context.GuidSerializers.Tests.csproj
+++ b/src/Context.GuidSerializer.Tests/Context.GuidSerializers.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCTestProjectProps)" Condition="Exists('$(CCTestProjectProps)')" />
+
+  <PropertyGroup>
+    <AssemblyName>MongoDB.Extensions.Context.GuidSerializers.Tests</AssemblyName>
+    <RootNamespace>MongoDB.Extensions.Context.GuidSerializers.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Context\Context.csproj" />
+    <ProjectReference Include="..\Prime.Extensions\Prime.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xunit.Priority" />
+  </ItemGroup>
+
+</Project>

--- a/src/Context.GuidSerializer.Tests/GuidSerializerTests.cs
+++ b/src/Context.GuidSerializer.Tests/GuidSerializerTests.cs
@@ -1,0 +1,71 @@
+using MongoDB.Driver;
+using Squadron;
+using Xunit;
+using System;
+using System.Threading.Tasks;
+using Snapshooter.Xunit;
+using MongoDB.Prime.Extensions;
+
+namespace MongoDB.Extensions.Context.GuidSerializers.Tests;
+
+public class GuidSerializerTests : IClassFixture<MongoResource>
+{
+    private readonly MongoOptions _mongoOptions;
+    private readonly IMongoDatabase _mongoDatabase;
+
+    public GuidSerializerTests(MongoResource mongoResource)
+    {
+        _mongoDatabase = mongoResource.CreateDatabase();
+        _mongoOptions = new MongoOptions
+        {
+            ConnectionString = mongoResource.ConnectionString,
+            DatabaseName = _mongoDatabase.DatabaseNamespace.DatabaseName
+        };
+    }
+
+    [Fact]
+    public async Task Serialize_GuidPropertyGuidSerialized_Successfully()
+    {
+        // Arrange
+        var foobarMongoDbContext = new FooBarMongoDbContext(_mongoOptions);
+
+        IMongoCollection<Foo> collection =
+            _mongoDatabase.GetCollection<Foo>("foos");
+
+        Foo foo = new Foo
+        (
+            fooId: Guid.Parse("b1eba0d6-a1f9-4e31-bd70-0feed19f4492"),
+            name: "test",
+            additionalId: Guid.Parse("b58ec857-c874-457e-8662-133a055282f6")
+        );
+
+        // Act
+        await collection.InsertOneAsync(foo);
+
+        // Assert
+        Snapshot.Match(collection.Dump());
+    }
+
+    [Fact]
+    public async Task Serialize_ObjectPropertyGuidSerialized_Successfully()
+    {
+        // Arrange
+        var foobarMongoDbContext = new FooBarMongoDbContext(_mongoOptions);
+
+        IMongoCollection<Bar> collection =
+            _mongoDatabase.GetCollection<Bar>("bars");
+
+        Bar bar = new Bar
+        (
+            fooId: Guid.Parse("b1eba0d6-a1f9-4e31-bd70-0feed19f4492"),
+            name: "test",
+            additionalId: Guid.Parse("b58ec857-c874-457e-8662-133a055282f6")
+        );
+
+        // Act
+        await collection.InsertOneAsync(bar);
+
+        // Assert
+        Snapshot.Match(collection.Dump());
+    }
+}

--- a/src/Context.GuidSerializer.Tests/Helpers/Bar.cs
+++ b/src/Context.GuidSerializer.Tests/Helpers/Bar.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace MongoDB.Extensions.Context.GuidSerializers.Tests;
+
+public class Bar
+{
+    public Bar(Guid fooId, string name, Guid additionalId)
+    {
+        Id = fooId;
+        Name = name;
+        AdditionalId = additionalId;
+    }
+
+    public Guid Id { get; private set; }
+
+    public string Name { get; private set;}
+
+    public object AdditionalId { get; private set;}
+}

--- a/src/Context.GuidSerializer.Tests/Helpers/Foo.cs
+++ b/src/Context.GuidSerializer.Tests/Helpers/Foo.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace MongoDB.Extensions.Context.GuidSerializers.Tests;
+
+public class Foo
+{
+    public Foo(Guid fooId, string name, Guid additionalId)
+    {
+        Id = fooId;
+        Name = name;
+        AdditionalId = additionalId;
+    }
+
+    public Guid Id { get; private set; }
+
+    public string Name { get; private set;}
+
+    public Guid AdditionalId { get; private set;}
+}

--- a/src/Context.GuidSerializer.Tests/Helpers/FooBarMongoDbContext.cs
+++ b/src/Context.GuidSerializer.Tests/Helpers/FooBarMongoDbContext.cs
@@ -1,0 +1,18 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace MongoDB.Extensions.Context.GuidSerializers.Tests;
+
+public class FooBarMongoDbContext : MongoDbContext
+{
+    public FooBarMongoDbContext(MongoOptions mongoOptions)
+        : base(mongoOptions)
+    {
+    }
+
+    protected override void OnConfiguring(
+        IMongoDatabaseBuilder databaseBuilder)
+    {
+        databaseBuilder.RegisterSerializer(new GuidSerializer(GuidRepresentation.CSharpLegacy));
+    }
+}

--- a/src/Context.GuidSerializer.Tests/__snapshots__/GuidSerializerTests.Serialize_GuidPropertyGuidSerialized_Successfully.snap
+++ b/src/Context.GuidSerializer.Tests/__snapshots__/GuidSerializerTests.Serialize_GuidPropertyGuidSerialized_Successfully.snap
@@ -1,0 +1,7 @@
+﻿[
+  {
+    "Id": "b1eba0d6-a1f9-4e31-bd70-0feed19f4492",
+    "Name": "test",
+    "AdditionalId": "b58ec857-c874-457e-8662-133a055282f6"
+  }
+]

--- a/src/Context.GuidSerializer.Tests/__snapshots__/GuidSerializerTests.Serialize_ObjectPropertyGuidSerialized_Successfully.snap
+++ b/src/Context.GuidSerializer.Tests/__snapshots__/GuidSerializerTests.Serialize_ObjectPropertyGuidSerialized_Successfully.snap
@@ -1,0 +1,7 @@
+﻿[
+  {
+    "Id": "b1eba0d6-a1f9-4e31-bd70-0feed19f4492",
+    "Name": "test",
+    "AdditionalId": "b58ec857-c874-457e-8662-133a055282f6"
+  }
+]

--- a/src/MongoDB.Extensions.sln
+++ b/src/MongoDB.Extensions.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Migration", "Migration\Migr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Migration.Tests", "Migration.Tests\Migration.Tests.csproj", "{D8F246AC-65CC-4EF0-B058-08970D269B61}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Context.GuidSerializers.Tests", "Context.GuidSerializer.Tests\Context.GuidSerializers.Tests.csproj", "{2E5C44AC-9F56-462F-B0B7-25F5995F5B76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{D8F246AC-65CC-4EF0-B058-08970D269B61}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8F246AC-65CC-4EF0-B058-08970D269B61}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8F246AC-65CC-4EF0-B058-08970D269B61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E5C44AC-9F56-462F-B0B7-25F5995F5B76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E5C44AC-9F56-462F-B0B7-25F5995F5B76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E5C44AC-9F56-462F-B0B7-25F5995F5B76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E5C44AC-9F56-462F-B0B7-25F5995F5B76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
If we register the GuidSerializer with the choosen GuidRepresentation (Standard, CSharpLegacy, JavaLegacy etc.), then the ObjectSerializer gets this GuidRepresentation not by default. The ObjectSerializer still throws the exception, that the GuidSerializer is not registered (or unknown). This extension adds the GuidRepresentation of the registered GuidSerializer to the ObjectSerializer as default.
