### PR TITLE
Add ISessionFactory for MongoSessionProvider

### DIFF
--- a/src/Session/ISessionFactory.cs
+++ b/src/Session/ISessionFactory.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace MongoDB.Extensions.Session;
+
+public interface ISessionFactory
+{
+    ValueTask<IClientSessionHandle> CreateSessionAsync(
+        CancellationToken cancellationToken);
+}

--- a/src/Session/Internal/MongoClientSessionFactory.cs
+++ b/src/Session/Internal/MongoClientSessionFactory.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace MongoDB.Extensions.Session;
+
+internal class MongoClientSessionFactory : ISessionFactory
+{
+    private readonly IMongoClient _client;
+
+    public MongoClientSessionFactory(IMongoClient client)
+    {
+        _client = client;
+    }
+    
+    public async ValueTask<IClientSessionHandle> CreateSessionAsync(
+        CancellationToken cancellationToken)
+    {
+        return await _client
+            .StartSessionAsync(cancellationToken: cancellationToken);
+    }
+}


### PR DESCRIPTION
This pull request refactors the session management architecture to introduce a new abstraction for creating MongoDB sessions. The changes primarily focus on decoupling session creation logic from the `MongoSessionProvider` by introducing an `ISessionFactory` interface and its implementation, `MongoClientSessionFactory`.

### Introduction of a session factory abstraction:
* [`src/Session/ISessionFactory.cs`](diffhunk://#diff-7f5c3dd917feada8d1652ee6ec50f02d92d7c7e887d168f3d7027e68d3f4fb53R1-R11): Added a new `ISessionFactory` interface to abstract the creation of MongoDB sessions. This interface defines the `CreateSessionAsync` method.
* [`src/Session/Internal/MongoClientSessionFactory.cs`](diffhunk://#diff-409bc66e72f9f99e2216b1282e27c729d83e4771028de1f5718d72f18a42f3dbR1-R22): Implemented the `ISessionFactory` interface in a new `MongoClientSessionFactory` class, which uses an `IMongoClient` to create sessions asynchronously.

### Refactoring of `MongoSessionProvider`:
* [`src/Session/Internal/MongoSessionProvider.cs`](diffhunk://#diff-f1ff50e7d0736b1074557c6e405e0d2f90ef40a5efd610b406528211278524a8L9-R24): Refactored `MongoSessionProvider` to use the new `ISessionFactory` abstraction. The base class now accepts an `ISessionFactory` instance, and the `BeginTransactionAsync` and `StartSessionAsync` methods delegate session creation to the factory. [[1]](diffhunk://#diff-f1ff50e7d0736b1074557c6e405e0d2f90ef40a5efd610b406528211278524a8L9-R24) [[2]](diffhunk://#diff-f1ff50e7d0736b1074557c6e405e0d2f90ef40a5efd610b406528211278524a8L28-R37) [[3]](diffhunk://#diff-f1ff50e7d0736b1074557c6e405e0d2f90ef40a5efd610b406528211278524a8L39-R48)