### PR TITLE
Remove TargetFramework from Oidc project file

### DIFF
--- a/src/Oidc/Oidc.csproj
+++ b/src/Oidc/Oidc.csproj
@@ -2,9 +2,7 @@
   <Import Project="$(CCResourceProjectProps)" Condition="Exists('$(CCResourceProjectProps)')" />
   
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Mongo.DB.Extensions.Context.Oidc</RootNamespace>
     <AssemblyName>Mongo.DB.Extensions.Context.Oidc</AssemblyName>
     <PackageId>Mongo.DB.Extensions.Context.Oidc</PackageId>

--- a/src/ResourceProject.props
+++ b/src/ResourceProject.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(ResourceProjectTargetFrameworks)</TargetFrameworks>    
     <IsPackable>true</IsPackable>
-	<LangVersion>10.0</LangVersion>
-	<Nullable>enable</Nullable>
+	  <LangVersion>10.0</LangVersion>
+	  <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Made the Oidc project like the context project with the reference, the framework and nullable settings can be removed.
