### PR TITLE
fix: Fix migrations on Nullable properties

### DIFF
--- a/src/Migration/MigrationSerializer.cs
+++ b/src/Migration/MigrationSerializer.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace MongoDB.Extensions.Migration;
 
-class MigrationSerializer<T> : SerializerBase<T>, IBsonIdProvider, IBsonDocumentSerializer, IBsonPolymorphicSerializer,
+class MigrationSerializer<T> : SerializerBase<T?>, IBsonIdProvider, IBsonDocumentSerializer, IBsonPolymorphicSerializer,
     IHasDiscriminatorConvention where T : IVersioned
 {
     private readonly EntityContext _context;
@@ -24,14 +24,22 @@ class MigrationSerializer<T> : SerializerBase<T>, IBsonIdProvider, IBsonDocument
     public override void Serialize(
         BsonSerializationContext context,
         BsonSerializationArgs args,
-        T value)
+        T? value)
     {
-        value.Version = _context.Option.CurrentVersion;
+        if(value is not null)
+        {
+            value.Version = _context.Option.CurrentVersion;
+        }
         _bsonClassMapSerializer.Serialize(context, args, value);
     }
 
-    public override T Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    public override T? Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
     {
+        if (context.Reader.GetCurrentBsonType() == BsonType.Null)
+        {
+            context.Reader.ReadNull();
+            return default;
+        }
         BsonDocument bsonDocument = BsonDocumentSerializer.Instance.Deserialize(context);
 
         _migrationRunner.Run(bsonDocument);

--- a/test/Migration.Tests/Unit/MigrationSerializerTests.cs
+++ b/test/Migration.Tests/Unit/MigrationSerializerTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Extensions.Migration;
+using Xunit;
+
+namespace Migration.Tests.Unit;
+
+public class MigrationSerializerTests 
+
+{
+    public record RootEntity(ChildEntity? Child);
+
+    public record ChildEntity(int Version, string Property) : IVersioned
+    {
+        public int Version { get; set; } = Version;
+    }
+
+    public class ChildEntityMigration : IMigration
+    {
+        public int Version => 1;
+
+        public void Up(BsonDocument document)
+        {
+            document["Property"] = document["Property"].AsString + " (migrated)";
+        }
+
+        public void Down(BsonDocument document)
+        {
+        }
+    }
+
+    [Fact]
+    public void Serialize_ContainsNull_SerializesCorrectly()
+    {
+        //ARRANGE
+        var entityOption = new EntityOption(typeof(ChildEntity), 1, [new ChildEntityMigration()]);
+        var migrationOption = new MigrationOption([entityOption]);
+        BsonSerializer.RegisterSerializationProvider(
+            new MigrationSerializerProvider(new MigrationContext(migrationOption, new NullLoggerFactory())));
+        var entityToSerialize = new RootEntity(null);
+        var stringWriter = new StringWriter();
+        var writer = new JsonWriter(stringWriter);
+
+        //ACT
+        BsonSerializer.Serialize(writer, entityToSerialize);
+        var result = stringWriter.ToString();
+
+        //ASSERT
+        result.Should().Be("""{ "Child" : null }""");
+    }
+
+    [Fact]
+    public void Deserialize_ContainsNull_DeserializesCorrectly()
+    {
+        //ARRANGE
+        var entityOption = new EntityOption(typeof(ChildEntity), 1, [new ChildEntityMigration()]);
+        var migrationOption = new MigrationOption([entityOption]);
+        BsonSerializer.RegisterSerializationProvider(
+            new MigrationSerializerProvider(new MigrationContext(migrationOption, new NullLoggerFactory())));
+
+        //ACT
+        var document = BsonDocument.Parse("""{ "Child" : null }""");
+        var entity = BsonSerializer.Deserialize<RootEntity>(document);
+
+        //ASSERT
+        entity.Should().NotBeNull();
+        entity.Child.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_ContainsNonNull_SerializesCorrectly()
+    {
+        //ARRANGE
+        var entityOption = new EntityOption(typeof(ChildEntity), 1, [new ChildEntityMigration()]);
+        var migrationOption = new MigrationOption([entityOption]);
+        BsonSerializer.RegisterSerializationProvider(
+            new MigrationSerializerProvider(new MigrationContext(migrationOption, new NullLoggerFactory())));
+        var entityToSerialize = new RootEntity(new ChildEntity(0, "Test"));
+        var stringWriter = new StringWriter();
+        var writer = new JsonWriter(stringWriter);
+
+        //ACT
+        BsonSerializer.Serialize(writer, entityToSerialize);
+        var result = stringWriter.ToString();
+
+        //ASSERT
+        //Migration happens on deserialization, so Property is not migrated
+        result.Should().Be("""{ "Child" : { "Property" : "Test", "Version" : 1 } }""");
+    }
+
+    [Fact]
+    public void Deserialize_ContainsNonNull_DeserializesCorrectly()
+    {
+        //ARRANGE
+        var entityOption = new EntityOption(typeof(ChildEntity), 1, [new ChildEntityMigration()]);
+        var migrationOption = new MigrationOption([entityOption]);
+        BsonSerializer.RegisterSerializationProvider(
+            new MigrationSerializerProvider(new MigrationContext(migrationOption, new NullLoggerFactory())));
+
+        //ACT
+        var document = BsonDocument.Parse("""{ "Child" : { "Property" : "Test", "Version" : 0 } }""");
+        var entity = BsonSerializer.Deserialize<RootEntity>(document);
+
+        //ASSERT
+        entity.Should().NotBeNull();
+        entity.Child.Should().NotBeNull();
+        entity.Child.Property.Should().Be("Test (migrated)");
+        entity.Child.Version.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Add null check to Serialization
- Add null parsing to Deserialization

Addresses #84 
